### PR TITLE
Enable ephemeral message, reply with BlockKit UI, and handling Interactive events

### DIFF
--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -212,15 +212,15 @@ module Ruboty
         action = data['actions'].first
         message_info = {
           from: data['channel'],
-          from_name: data['user']['name'],
-          to: data['channel']['id'],
-          channel: data['channel']['id'],
+          from_name: data.dig('user', 'name'),
+          to: data.dig('channel', 'id'),
+          channel: data.dig('channel', 'id'),
           user: data['user'],
           url: data["response_url"],
           action_value: action['value'],
           ts: action['action_ts'],
           time: Time.at(action['action_ts'].to_f),
-          body: "#{ENV['RUBOTY_NAME']} slack_interactive::#{action['action_id']}",
+          body: "#{ruboty_name} slack_interactive::#{action['action_id']}",
           data: data,
         }
         robot.receive(message_info)
@@ -432,6 +432,10 @@ module Ruboty
 
       def slack_auto_reconnect
         ENV['SLACK_AUTO_RECONNECT']
+      end
+
+      def ruboty_name
+        ENV['RUBOTY_NAME']
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/client.rb
+++ b/lib/ruboty/slack_socket_mode/client.rb
@@ -27,6 +27,8 @@ module Ruboty
           when :text
             Ruboty.logger.debug("#{Client.name}: Received text message: #{message.data}")
             data = JSON.parse(message.data)
+            Ruboty.logger.debug("#{Client.name}: Received text message")
+            Ruboty.logger.debug(message.data)
 
             # ACK response for SocketMode
             # ref: https://api.slack.com/apis/connections/socket-implement#acknowledge

--- a/lib/ruboty/slack_socket_mode/message.rb
+++ b/lib/ruboty/slack_socket_mode/message.rb
@@ -8,6 +8,14 @@ module Ruboty
         timestamp  = @original[:time].to_f
         robot.add_reaction(reaction, channel_id, timestamp)
       end
+
+      def reply_ephemeral(body, options = {})
+        reply(body, options.merge(ephemeral: true))
+      end
+
+      def delete
+        robot.delete_ephemeral_message(@original[:data]["response_url"])
+      end
     end
   end
 

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -9,6 +9,10 @@ module Ruboty
         adapter.add_reaction(reaction, channel_id, timestamp)
         true
       end
+
+      def delete_ephemeral_message(response_url)
+        adapter.delete_ephemeral_message(response_url)
+      end
     end
   end
 

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,0 +1,24 @@
+require "ruboty/sample_plugin/version"
+
+module Ruboty
+  module Handlers
+    class Interactive < Base
+      on(
+        /slack_interactive\:\:(?<action>.*)\z/,
+        name: 'slack_interactive',
+        description: 'Slack Interactive callback'
+      )
+
+      def slack_interactive(message)
+        action = message.match_data[:action]
+        interactive(action, message)
+      end
+
+      def interactive(action, message)
+        if action == 'action_ephemeral_ok'
+          message.delete
+        end
+      end
+    end
+  end
+end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -1,0 +1,60 @@
+require "ruboty/sample_plugin/version"
+
+module Ruboty
+  module Handlers
+    class Trigger < Base
+      on(
+        /attachment/i,
+        name: 'reply_with_attachments',
+        description: 'reply with attachments',
+      )
+      on(
+        /file/i,
+        name: 'reply_with_file_attachment',
+        description: 'reply with a file attachment',
+      )
+      on(
+        /ephemeral/i,
+        name: 'reply_ephemeral',
+        description: 'reply elphemeral message',
+      )
+
+      def reply_with_attachments(message)
+        message.reply('', attachments: [{
+          "text": "This is an attachment",
+          "id": 1,
+          "fallback": "This is an attachment's fallback"
+        }])
+      end
+
+      def reply_with_file_attachment(message)
+        message.reply('', file: {
+            path: 'sample_file',
+            title: 'sample_file',
+            content_type: 'text/plain'
+          }
+        )
+      end
+
+      def reply_ephemeral(message)
+        message.reply_ephemeral(
+          'this is ephemeral message',
+          blocks: [
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "This is ephemeral message"
+              },
+              "accessory": {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "OK" },
+                "action_id": "action_ephemeral_ok"
+              }
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/sample/ruboty-sample_plugin/lib/ruboty/sample_plugin.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/sample_plugin.rb
@@ -1,35 +1,3 @@
-require "ruboty/sample_plugin/version"
-
-module Ruboty
-  module Handlers
-    class SamplePlugin < Base
-      on(
-        /attachment/i,
-        name: 'reply_with_attachments',
-        description: 'reply with attachments',
-      )
-      on(
-        /file/i,
-        name: 'reply_with_file_attachment',
-        description: 'reply with a file attachment',
-      )
-
-      def reply_with_attachments(message)
-        message.reply('', attachments: [{
-          "text": "This is an attachment",
-          "id": 1,
-          "fallback": "This is an attachment's fallback"
-        }])
-      end
-
-      def reply_with_file_attachment(message)
-        message.reply('', file: {
-            path: 'sample_file',
-            title: 'sample_file',
-            content_type: 'text/plain'
-          }
-        )
-      end
-    end
-  end
-end
+require 'ruboty/sample_plugin/version'
+require 'ruboty/handlers/trigger'
+require 'ruboty/handlers/interactive'


### PR DESCRIPTION
## Sample Image
![Untitled](https://user-images.githubusercontent.com/98291974/167752829-e0b1a1a9-93c5-4895-bfc5-065337d393e9.gif)

### implement `Message#replyEphemeral`
Ruboty applications can reply message as [ephemeral message](https://api.slack.com/methods/chat.postEphemeral).

### `Message#reply` `Message#replyEphemeral` can receive `block` argument
These methods can handle [BlockKit](https://api.slack.com/block-kit) JSON as argument: `block`.

### (experimental) Interactive events of BlockKit can be passed to handlers
This is experimental feature. 
BlockKit's interactive events is handled as Ruboty-command: `slack_interactive::#{action_id}`.
Ruboty handlers can receive them by catching above command.

### (experimental) implement `Message#delete` for ephemeral message interaction
This is experimental feature. 
Ruboty message made from BlockKit's interactive events can use `delete` method.
This is useful to clean up ephemeral message containing BlockKit UI.
It can be used only for ephemeral message.




