### PR TITLE
Handling Events API / Interactive on exclusive handler routes

### DIFF
--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -26,12 +26,6 @@ module Ruboty
 
       def say(message)
         channel = message[:to]
-        if channel[0] == '#'
-          channel = resolve_channel_id(channel[1..-1])
-        end
-
-        return unless channel
-
         args = {
           as_user: true,
           channel: channel
@@ -72,7 +66,7 @@ module Ruboty
         end
 
         if message[:ephemeral]
-          args.merge!(user: message[:original][:user]['id'])
+          args.merge!(user: message[:user_id])
           client.chat_postEphemeral(args)
         else
           client.chat_postMessage(args)

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -2,8 +2,10 @@ require 'cgi'
 require 'time'
 require 'json'
 require 'slack'
-require 'ruboty/adapters/base'
 require 'faraday'
+
+require 'ruboty/adapters/base'
+require 'ruboty/slack_socket_mode/interactive_message'
 
 module Ruboty
   module Adapters
@@ -137,8 +139,8 @@ module Ruboty
       end
 
       def handle_interactive(data)
-        # TODO: add event handling for Block Kit buttons
-        robot.receive_interactive(data['type'], data)
+        interactive_message = Ruboty::SlackSocketMode::InteractiveMessage.new(robot, data)
+        robot.receive_interactive(interactive_message)
       end
 
       def connect

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -118,20 +118,27 @@ module Ruboty
             # auto reconnecting works if SLACK_AUTO_RECONNECT configured.
           when 'events_api'
             event = data.dig('payload', 'event')
+            handle_events_api(data['payload']['event'])
+
             method_name = :"on_#{event['type']}"
-            if respond_to?(method_name, true)
-              send(method_name, event)
-            else
-              Ruboty.logger.warn("#{self.class.name}: Received unsupported events_api type: '#{event['type']}'.")
-            end
+            send(method_name, event) if respond_to?(method_name, true)
           when 'slash_commands'
             # TODO: add event handling for Slash commands
           when 'interactive'
-            interactive(data['payload'])
+            handle_interactive(data['payload'])
           else
             Ruboty.logger.warn("#{self.class.name}: Received unsupported data type: '#{data['type']}'.")
           end
         end
+      end
+
+      def handle_events_api(data)
+        robot.receive_events_api(data['type'], data)
+      end
+
+      def handle_interactive(data)
+        # TODO: add event handling for Block Kit buttons
+        robot.receive_interactive(data['type'], data)
       end
 
       def connect

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -212,15 +212,15 @@ module Ruboty
         action = data['actions'].first
         message_info = {
           from: data['channel'],
-          from_name: data['user']['name'],
-          to: data['channel']['id'],
-          channel: data['channel']['id'],
+          from_name: data.dig('user', 'name'),
+          to: data.dig('channel', 'id'),
+          channel: data.dig('channel', 'id'),
           user: data['user'],
           url: data["response_url"],
           action_value: action['value'],
           ts: action['action_ts'],
           time: Time.at(action['action_ts'].to_f),
-          body: "#{ENV['RUBOTY_NAME']} slack_interactive::#{action['action_id']}",
+          body: "#{ruboty_name} slack_interactive::#{action['action_id']}",
           data: data,
         }
         robot.receive(message_info)
@@ -432,6 +432,10 @@ module Ruboty
 
       def slack_auto_reconnect
         ENV['SLACK_AUTO_RECONNECT']
+      end
+
+      def ruboty_name
+        ENV['RUBOTY_NAME']
       end
     end
   end

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -211,24 +211,6 @@ module Ruboty
       # ref: https://api.slack.com/events/app_mention
       alias_method :on_message, :on_app_mention
 
-      def interactive(data)
-        action = data['actions'].first
-        message_info = {
-          from: data['channel'],
-          from_name: data.dig('user', 'name'),
-          to: data.dig('channel', 'id'),
-          channel: data.dig('channel', 'id'),
-          user: data['user'],
-          url: data["response_url"],
-          action_value: action['value'],
-          ts: action['action_ts'],
-          time: Time.at(action['action_ts'].to_f),
-          body: "#{ruboty_name} slack_interactive::#{action['action_id']}",
-          data: data,
-        }
-        robot.receive(message_info)
-      end
-
       def on_channel_change(data)
         make_channels_cache
       end

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -118,7 +118,7 @@ module Ruboty
             # auto reconnecting works if SLACK_AUTO_RECONNECT configured.
           when 'events_api'
             event = data.dig('payload', 'event')
-            handle_events_api(data['payload']['event'])
+            handle_events_api(event)
 
             method_name = :"on_#{event['type']}"
             send(method_name, event) if respond_to?(method_name, true)

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -77,16 +77,20 @@ module Ruboty
         client.reactions_add(name: reaction, channel: channel_id, timestamp: timestamp)
       end
 
-      def delete_ephemeral_message(response_url)
-        uri = URI.parse(response_url)
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = uri.scheme === "https"
+      def delete_interactive(response_url)
         params = { delete_original: "true" }
-        headers = { "Content-Type" => "application/json" }
-        http.post(uri.path, params.to_json, headers)
+        post_as_json(response_url, params)
       end
 
       private
+
+      def post_as_json(url, params)
+        uri = URI.parse(url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme === "https"
+        headers = { "Content-Type" => "application/json" }
+        http.post(uri.path, params.to_json, headers)
+      end
 
       def init
         response = client.auth_test

--- a/lib/ruboty/slack_socket_mode.rb
+++ b/lib/ruboty/slack_socket_mode.rb
@@ -1,5 +1,11 @@
 require 'ruboty/slack_socket_mode/version'
-require 'ruboty/slack_socket_mode/client'
-require 'ruboty/adapters/slack_socket_mode'
+
+require 'ruboty/slack_socket_mode/handlers'
+require 'ruboty/slack_socket_mode/handlers/events_api_handler'
+require 'ruboty/slack_socket_mode/handlers/interactive_handler'
+
 require 'ruboty/slack_socket_mode/robot'
 require 'ruboty/slack_socket_mode/message'
+require 'ruboty/slack_socket_mode/client'
+
+require 'ruboty/adapters/slack_socket_mode'

--- a/lib/ruboty/slack_socket_mode/client.rb
+++ b/lib/ruboty/slack_socket_mode/client.rb
@@ -27,6 +27,8 @@ module Ruboty
           when :text
             Ruboty.logger.debug("#{Client.name}: Received text message: #{message.data}")
             data = JSON.parse(message.data)
+            Ruboty.logger.debug("#{Client.name}: Received text message")
+            Ruboty.logger.debug(message.data)
 
             # ACK response for SocketMode
             # ref: https://api.slack.com/apis/connections/socket-implement#acknowledge

--- a/lib/ruboty/slack_socket_mode/events_api_command.rb
+++ b/lib/ruboty/slack_socket_mode/events_api_command.rb
@@ -1,0 +1,12 @@
+module Ruboty
+  module SlackSocketMode
+    class EventsApiCommand
+      attr_reader :event_type, :method_name
+
+      def initialize(event_type, method_name)
+        @event_type = event_type
+        @method_name = method_name
+      end
+    end
+  end
+end

--- a/lib/ruboty/slack_socket_mode/handlers.rb
+++ b/lib/ruboty/slack_socket_mode/handlers.rb
@@ -15,11 +15,6 @@ module Ruboty
           []
         end
         memoize :interactive
-
-        def slash_commands
-          []
-        end
-        memoize :slash_commands
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/handlers.rb
+++ b/lib/ruboty/slack_socket_mode/handlers.rb
@@ -1,0 +1,26 @@
+require 'ruboty'
+
+module Ruboty
+  module SlackSocketMode
+    module Handlers
+      class << self
+        include Mem
+
+        def events_api
+          []
+        end
+        memoize :events_api
+
+        def interactive
+          []
+        end
+        memoize :interactive
+
+        def slash_commands
+          []
+        end
+        memoize :slash_commands
+      end
+    end
+  end
+end

--- a/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
@@ -3,6 +3,15 @@ require "ostruct"
 module Ruboty
   module SlackSocketMode
     module Handlers
+      class EventsApiAction
+        attr_reader :event_type, :method_name
+
+        def initialize(event_type, method_name)
+          @event_type = event_type
+          @method_name = method_name
+        end
+      end
+
       class EventsApiHandler
         class << self
           include Mem
@@ -11,8 +20,8 @@ module Ruboty
             Ruboty::SlackSocketMode::Handlers.events_api << child
           end
 
-          def on(event_type:, name:)
-            actions << OpenStruct.new(event_type: event_type, method_name: name)
+          def on_event(event_type:, name:)
+            actions << EventsApiAction.new(event_type, name)
           end
 
           def actions
@@ -21,13 +30,10 @@ module Ruboty
           memoize :actions
         end
 
-        include Env::Validatable
-
         attr_reader :robot
 
         def initialize(robot)
           @robot = robot
-          validate!
         end
       end
     end

--- a/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
@@ -1,17 +1,8 @@
-require "ostruct"
+require 'ruboty/slack_socket_mode/events_api_command'
 
 module Ruboty
   module SlackSocketMode
     module Handlers
-      class EventsApiAction
-        attr_reader :event_type, :method_name
-
-        def initialize(event_type, method_name)
-          @event_type = event_type
-          @method_name = method_name
-        end
-      end
-
       class EventsApiHandler
         class << self
           include Mem
@@ -21,13 +12,13 @@ module Ruboty
           end
 
           def on_event(event_type:, name:)
-            actions << EventsApiAction.new(event_type, name)
+            commands << Ruboty::SlackSocketMode::EventsApiCommand.new(event_type, name)
           end
 
-          def actions
+          def commands
             []
           end
-          memoize :actions
+          memoize :commands
         end
 
         attr_reader :robot

--- a/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
@@ -1,0 +1,35 @@
+require "ostruct"
+
+module Ruboty
+  module SlackSocketMode
+    module Handlers
+      class EventsApiHandler
+        class << self
+          include Mem
+
+          def inherited(child)
+            Ruboty::SlackSocketMode::Handlers.events_api << child
+          end
+
+          def on(event_type:, name:)
+            actions << OpenStruct.new(event_type: event_type, method_name: name)
+          end
+
+          def actions
+            []
+          end
+          memoize :actions
+        end
+
+        include Env::Validatable
+
+        attr_reader :robot
+
+        def initialize(robot)
+          @robot = robot
+          validate!
+        end
+      end
+    end
+  end
+end

--- a/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
@@ -1,16 +1,8 @@
-require "ostruct"
+require 'ruboty/slack_socket_mode/interactive_command'
 
 module Ruboty
   module SlackSocketMode
     module Handlers
-      class InteractiveAction
-        attr_reader :action_id, :method_name
-
-        def initialize(action_id, method_name)
-          @action_id = action_id
-          @method_name = method_name
-        end
-      end
 
       class InteractiveHandler
         class << self
@@ -21,13 +13,13 @@ module Ruboty
           end
 
           def on_interactive(action_id:, name:)
-            actions << InteractiveAction.new(action_id, name)
+            commands << Ruboty::SlackSocketMode::InteractiveCommand.new(action_id, name)
           end
 
-          def actions
+          def commands
             []
           end
-          memoize :actions
+          memoize :commands
         end
 
         attr_reader :robot

--- a/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
@@ -3,6 +3,15 @@ require "ostruct"
 module Ruboty
   module SlackSocketMode
     module Handlers
+      class InteractiveAction
+        attr_reader :action_id, :method_name
+
+        def initialize(action_id, method_name)
+          @action_id = action_id
+          @method_name = method_name
+        end
+      end
+
       class InteractiveHandler
         class << self
           include Mem
@@ -11,8 +20,8 @@ module Ruboty
             Ruboty::SlackSocketMode::Handlers.interactive << child
           end
 
-          def on(action_id:, name:)
-            actions << OpenStruct.new(action_id: action_id, method_name: name)
+          def on_interactive(action_id:, name:)
+            actions << InteractiveAction.new(action_id, name)
           end
 
           def actions
@@ -21,13 +30,10 @@ module Ruboty
           memoize :actions
         end
 
-        include Env::Validatable
-
         attr_reader :robot
 
         def initialize(robot)
           @robot = robot
-          validate!
         end
       end
     end

--- a/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
@@ -1,0 +1,35 @@
+require "ostruct"
+
+module Ruboty
+  module SlackSocketMode
+    module Handlers
+      class InteractiveHandler
+        class << self
+          include Mem
+
+          def inherited(child)
+            Ruboty::SlackSocketMode::Handlers.interactive << child
+          end
+
+          def on(action_id:, name:)
+            actions << OpenStruct.new(action_id: action_id, method_name: name)
+          end
+
+          def actions
+            []
+          end
+          memoize :actions
+        end
+
+        include Env::Validatable
+
+        attr_reader :robot
+
+        def initialize(robot)
+          @robot = robot
+          validate!
+        end
+      end
+    end
+  end
+end

--- a/lib/ruboty/slack_socket_mode/interactive_command.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_command.rb
@@ -1,0 +1,12 @@
+module Ruboty
+  module SlackSocketMode
+    class InteractiveCommand
+      attr_reader :action_id, :method_name
+
+      def initialize(action_id, method_name)
+        @action_id = action_id
+        @method_name = method_name
+      end
+    end
+  end
+end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -12,11 +12,15 @@ module Ruboty
       end
 
       def from
-        @payload.dig("channel", "id")
+        payload.dig("channel", "id")
+      end
+
+      def from_name
+        payload.dig("user", "name")
       end
 
       def user_id
-        @payload.dig("user", "id")
+        payload.dig("user", "id")
       end
 
       def reply(body, options = {})
@@ -25,7 +29,7 @@ module Ruboty
           return
         end
 
-        attributes = { body: body, to: from, original: @payload }.merge(options)
+        attributes = { body: body, to: from, original: payload }.merge(options)
         robot.say(attributes)
       end
 
@@ -34,11 +38,11 @@ module Ruboty
       end
 
       def delete
-        unless @payload['response_url']
+        unless payload['response_url']
           Ruboty.logger.warn("#{self.class.name}: Cannot delete message. This is not an ephemeral message.")
           return
         end
-        @robot.delete_ephemeral_message(@payload['response_url'])
+        @robot.delete_ephemeral_message(payload['response_url'])
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -1,0 +1,27 @@
+require 'ruboty/message'
+
+module Ruboty
+  module SlackSocketMode
+    class InteractiveMessage
+      attr_reader :action_id, :payload
+
+      def initialize(robot, payload)
+        @robot = robot
+        @payload = payload
+        @action_id = payload['actions'].first['action_id']
+      end
+
+      def delete
+        unless @payload['response_url']
+          Ruboty.logger.warn("#{self.class.name}: Cannot delete message. This is not an ephemeral message.")
+          return
+        end
+        @robot.delete_ephemeral_message(@payload['response_url'])
+      end
+
+      private
+
+      attr_reader :robot
+    end
+  end
+end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -12,15 +12,15 @@ module Ruboty
       end
 
       def from
-        payload.dig("channel", "id")
+        @payload.dig("channel", "id")
       end
 
       def from_name
-        payload.dig("user", "name")
+        @payload.dig("user", "name")
       end
 
       def user_id
-        payload.dig("user", "id")
+        @payload.dig("user", "id")
       end
 
       def reply(body, options = {})
@@ -29,7 +29,7 @@ module Ruboty
           return
         end
 
-        attributes = { body: body, to: from, original: payload }.merge(options)
+        attributes = { body: body, to: from, original: @payload }.merge(options)
         robot.say(attributes)
       end
 
@@ -38,7 +38,7 @@ module Ruboty
       end
 
       def delete
-        response_url = payload['response_url']
+        response_url = @payload['response_url']
         unless response_url
           Ruboty.logger.warn("#{self.class.name}: Cannot delete message. This message does not contain response_url in payload.")
           return

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -3,12 +3,34 @@ require 'ruboty/message'
 module Ruboty
   module SlackSocketMode
     class InteractiveMessage
-      attr_reader :action_id, :payload
+      attr_reader :robot, :action_id, :payload
 
       def initialize(robot, payload)
         @robot = robot
         @payload = payload
         @action_id = payload['actions'].first['action_id']
+      end
+
+      def from
+        @payload.dig("channel", "id")
+      end
+
+      def user_id
+        @payload.dig("user", "id")
+      end
+
+      def reply(body, options = {})
+        unless from
+          Ruboty.logger.warn("#{self.class.name}: Cannot reply message. Destination channel is not found.")
+          return
+        end
+
+        attributes = { body: body, to: from, original: @payload }.merge(options)
+        robot.say(attributes)
+      end
+
+      def reply_ephemeral(body, options = {})
+        reply(body, options.merge(ephemeral: true, user_id: user_id))
       end
 
       def delete
@@ -18,10 +40,6 @@ module Ruboty
         end
         @robot.delete_ephemeral_message(@payload['response_url'])
       end
-
-      private
-
-      attr_reader :robot
     end
   end
 end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -33,16 +33,18 @@ module Ruboty
         robot.say(attributes)
       end
 
-      def reply_ephemeral(body, options = {})
+      def reply_as_ephemeral(body, options = {})
         reply(body, options.merge(ephemeral: true, user_id: user_id))
       end
 
       def delete
-        unless payload['response_url']
-          Ruboty.logger.warn("#{self.class.name}: Cannot delete message. This is not an ephemeral message.")
+        response_url = payload['response_url']
+        unless response_url
+          Ruboty.logger.warn("#{self.class.name}: Cannot delete message. This message does not contain response_url in payload.")
           return
         end
-        @robot.delete_ephemeral_message(payload['response_url'])
+
+        robot.delete_interactive(response_url)
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/message.rb
+++ b/lib/ruboty/slack_socket_mode/message.rb
@@ -13,7 +13,7 @@ module Ruboty
         @original.dig(:user, "id")
       end
 
-      def reply_ephemeral(body, options = {})
+      def reply_as_ephemeral(body, options = {})
         reply(body, options.merge(ephemeral: true, user_id: user_id))
       end
 

--- a/lib/ruboty/slack_socket_mode/message.rb
+++ b/lib/ruboty/slack_socket_mode/message.rb
@@ -16,10 +16,6 @@ module Ruboty
       def reply_as_ephemeral(body, options = {})
         reply(body, options.merge(ephemeral: true, user_id: user_id))
       end
-
-      def delete
-        robot.delete_ephemeral_message(@original[:data]["response_url"])
-      end
     end
   end
 

--- a/lib/ruboty/slack_socket_mode/message.rb
+++ b/lib/ruboty/slack_socket_mode/message.rb
@@ -8,6 +8,14 @@ module Ruboty
         timestamp  = @original[:time].to_f
         robot.add_reaction(reaction, channel_id, timestamp)
       end
+
+      def reply_ephemeral(body, options = {})
+        reply(body, options.merge(ephemeral: true))
+      end
+
+      def delete
+        robot.delete_ephemeral_message(@original[:data]["response_url"])
+      end
     end
   end
 

--- a/lib/ruboty/slack_socket_mode/message.rb
+++ b/lib/ruboty/slack_socket_mode/message.rb
@@ -9,8 +9,12 @@ module Ruboty
         robot.add_reaction(reaction, channel_id, timestamp)
       end
 
+      def user_id
+        @original.dig(:user, "id")
+      end
+
       def reply_ephemeral(body, options = {})
-        reply(body, options.merge(ephemeral: true))
+        reply(body, options.merge(ephemeral: true, user_id: user_id))
       end
 
       def delete

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -5,14 +5,11 @@ module Ruboty
     module Robot
       include Mem
       delegate :add_reaction, to: :adapter
+      delegate :delete_interactive, to: :adapter
 
       def add_reaction(reaction, channel_id, timestamp)
         adapter.add_reaction(reaction, channel_id, timestamp)
         true
-      end
-
-      def delete_ephemeral_message(response_url)
-        adapter.delete_ephemeral_message(response_url)
       end
 
       def receive_events_api(event_type, data)

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -9,6 +9,10 @@ module Ruboty
         adapter.add_reaction(reaction, channel_id, timestamp)
         true
       end
+
+      def delete_ephemeral_message(response_url)
+        adapter.delete_ephemeral_message(response_url)
+      end
     end
   end
 

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -23,10 +23,10 @@ module Ruboty
         end
       end
 
-      def receive_interactive(action_id, data)
+      def receive_interactive(interactive_message)
         interactive_handlers.each do |handler|
           handler.class.actions.each do |action|
-            handler.send(action.method_name, data) if action.action_id == action_id
+            handler.send(action.method_name, interactive_message) if action.action_id == interactive_message.action_id
           end
         end
       end

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -3,6 +3,7 @@ require 'ruboty/robot'
 module Ruboty
   module SlackSocketMode
     module Robot
+      include Mem
       delegate :add_reaction, to: :adapter
 
       def add_reaction(reaction, channel_id, timestamp)
@@ -13,6 +14,34 @@ module Ruboty
       def delete_ephemeral_message(response_url)
         adapter.delete_ephemeral_message(response_url)
       end
+
+      def receive_events_api(event_type, data)
+        events_api_handlers.each do |handler|
+          handler.class.actions.each do |action|
+            handler.send(action.method_name, data) if action.event_type == event_type
+          end
+        end
+      end
+
+      def receive_interactive(action_id, data)
+        interactive_handlers.each do |handler|
+          handler.class.actions.each do |action|
+            handler.send(action.method_name, data) if action.action_id == action_id
+          end
+        end
+      end
+
+      private
+
+      def events_api_handlers
+        Handlers.events_api.map { |handler_class| handler_class.new(self) }
+      end
+      memoize :events_api_handlers
+
+      def interactive_handlers
+        Handlers.interactive.map { |handler_class| handler_class.new(self) }
+      end
+      memoize :interactive_handlers
     end
   end
 

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -14,16 +14,16 @@ module Ruboty
 
       def receive_events_api(event_type, data)
         events_api_handlers.each do |handler|
-          handler.class.actions.each do |action|
-            handler.send(action.method_name, data) if action.event_type == event_type
+          handler.class.commands.each do |command|
+            handler.send(command.method_name, data) if command.event_type == event_type
           end
         end
       end
 
       def receive_interactive(interactive_message)
         interactive_handlers.each do |handler|
-          handler.class.actions.each do |action|
-            handler.send(action.method_name, interactive_message) if action.action_id == interactive_message.action_id
+          handler.class.commands.each do |command|
+            handler.send(command.method_name, interactive_message) if command.action_id == interactive_message.action_id
           end
         end
       end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/events_api.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/events_api.rb
@@ -1,0 +1,13 @@
+module Ruboty::SlackSocketMode::Handlers
+  class EventsApi < EventsApiHandler
+    on(
+      event_type: 'app_home_opened',
+      name: 'app_home_opened'
+    )
+
+    def app_home_opened(message)
+      pp 'app_home_opened!'
+      pp message
+    end
+  end
+end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/events_api.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/events_api.rb
@@ -1,13 +1,12 @@
 module Ruboty::SlackSocketMode::Handlers
   class EventsApi < EventsApiHandler
-    on(
+    on_event(
       event_type: 'app_home_opened',
       name: 'app_home_opened'
     )
 
     def app_home_opened(message)
-      pp 'app_home_opened!'
-      pp message
+      puts "App Home: #{message["tab"]} tab is opened!"
     end
   end
 end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,0 +1,24 @@
+require "ruboty/sample_plugin/version"
+
+module Ruboty
+  module Handlers
+    class Interactive < Base
+      on(
+        /slack_interactive\:\:(?<action>.*)\z/,
+        name: 'slack_interactive',
+        description: 'Slack Interactive callback'
+      )
+
+      def slack_interactive(message)
+        action = message.match_data[:action]
+        interactive(action, message)
+      end
+
+      def interactive(action, message)
+        if action == 'action_ephemeral_ok'
+          message.delete
+        end
+      end
+    end
+  end
+end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,17 +1,20 @@
 module Ruboty::SlackSocketMode::Handlers
   class Interactive < InteractiveHandler
     on_interactive(
-      action_id: 'action_ephemeral_ok',
-      name: 'ephemeral_ok'
+      action_id: 'action_ephemeral_delete',
+      name: 'delete'
     )
     on_interactive(
-      action_id: 'increment',
-      name: 'ephemeral_ok'
+      action_id: 'action_ephemeral_more',
+      name: 'more'
     )
 
-    def ephemeral_ok(message)
+    def delete(message)
       message.delete
-      message.reply_ephemeral("Hello")
+    end
+
+    def more(message)
+      message.reply_ephemeral("Hello!")
     end
   end
 end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -4,9 +4,14 @@ module Ruboty::SlackSocketMode::Handlers
       action_id: 'action_ephemeral_ok',
       name: 'ephemeral_ok'
     )
+    on_interactive(
+      action_id: 'increment',
+      name: 'ephemeral_ok'
+    )
 
     def ephemeral_ok(message)
       message.delete
+      message.reply_ephemeral("Hello")
     end
   end
 end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,12 +1,16 @@
 module Ruboty::SlackSocketMode::Handlers
   class Interactive < InteractiveHandler
     on_interactive(
-      action_id: 'action_ephemeral_delete',
+      action_id: 'action_delete',
       name: 'delete'
     )
     on_interactive(
-      action_id: 'action_ephemeral_more',
+      action_id: 'action_more',
       name: 'more'
+    )
+    on_interactive(
+      action_id: 'action_more_ephemeral',
+      name: 'more_ephemeral'
     )
 
     def delete(message)
@@ -14,7 +18,11 @@ module Ruboty::SlackSocketMode::Handlers
     end
 
     def more(message)
-      message.reply_ephemeral("Hello!")
+      message.reply("Hello, #{message.from_name}!")
+    end
+
+    def more_ephemeral(message)
+      message.reply_as_ephemeral("Hello, #{message.from_name}!")
     end
   end
 end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,23 +1,13 @@
-require "ruboty/sample_plugin/version"
+module Ruboty::SlackSocketMode::Handlers
+  class Interactive < InteractiveHandler
+    on(
+      action_id: 'action_ephemeral_ok',
+      name: 'slack_interactive'
+    )
 
-module Ruboty
-  module Handlers
-    class Interactive < Base
-      on(
-        /slack_interactive\:\:(?<action>.*)\z/,
-        name: 'slack_interactive',
-        description: 'Slack Interactive callback'
-      )
-
-      def slack_interactive(message)
-        action = message.match_data[:action]
-        interactive(action, message)
-      end
-
-      def interactive(action, message)
-        if action == 'action_ephemeral_ok'
-          message.delete
-        end
+    def interactive(action, message)
+      if action == 'action_ephemeral_ok'
+        message.delete
       end
     end
   end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,14 +1,12 @@
 module Ruboty::SlackSocketMode::Handlers
   class Interactive < InteractiveHandler
-    on(
+    on_interactive(
       action_id: 'action_ephemeral_ok',
-      name: 'slack_interactive'
+      name: 'ephemeral_ok'
     )
 
-    def interactive(action, message)
-      if action == 'action_ephemeral_ok'
-        message.delete
-      end
+    def ephemeral_ok(message)
+      message.delete
     end
   end
 end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -1,0 +1,60 @@
+require "ruboty/sample_plugin/version"
+
+module Ruboty
+  module Handlers
+    class Trigger < Base
+      on(
+        /attachment/i,
+        name: 'reply_with_attachments',
+        description: 'reply with attachments',
+      )
+      on(
+        /file/i,
+        name: 'reply_with_file_attachment',
+        description: 'reply with a file attachment',
+      )
+      on(
+        /ephemeral/i,
+        name: 'reply_ephemeral',
+        description: 'reply elphemeral message',
+      )
+
+      def reply_with_attachments(message)
+        message.reply('', attachments: [{
+          "text": "This is an attachment",
+          "id": 1,
+          "fallback": "This is an attachment's fallback"
+        }])
+      end
+
+      def reply_with_file_attachment(message)
+        message.reply('', file: {
+            path: 'sample_file',
+            title: 'sample_file',
+            content_type: 'text/plain'
+          }
+        )
+      end
+
+      def reply_ephemeral(message)
+        message.reply_ephemeral(
+          'this is ephemeral message',
+          blocks: [
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "This is ephemeral message"
+              },
+              "accessory": {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "OK" },
+                "action_id": "action_ephemeral_ok"
+              }
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -4,19 +4,24 @@ module Ruboty
   module Handlers
     class Trigger < Base
       on(
-        /attachment/i,
+        /attachment\z/i,
         name: 'reply_with_attachments',
         description: 'reply with attachments',
       )
       on(
-        /file/i,
+        /file\z/i,
         name: 'reply_with_file_attachment',
         description: 'reply with a file attachment',
       )
       on(
-        /ephemeral/i,
-        name: 'reply_ephemeral',
-        description: 'reply elphemeral message',
+        /interactive\z/i,
+        name: 'reply_interactive',
+        description: 'reply an interactive message',
+      )
+      on(
+        /interactive_ephemeral\z/i,
+        name: 'reply_interactive_as_ephemeral',
+        description: 'reply an interactive message as ephemeral',
       )
 
       def reply_with_attachments(message)
@@ -36,31 +41,43 @@ module Ruboty
         )
       end
 
-      def reply_ephemeral(message)
-        message.reply_ephemeral(
-          'this is ephemeral message',
-          blocks: [
-            {
-              "type": "section",
-              "text": { "type": "plain_text", "text": "This is ephemeral message" }
-            },
-            {
-              "type": "actions",
-              "elements": [
-                {
-                  "type": "button",
-                  "text": { "type": "plain_text", "text": "Delete" },
-                  "action_id": "action_ephemeral_delete"
-                },
-                {
-                  "type": "button",
-                  "text": { "type": "plain_text", "text": "More Message" },
-                  "action_id": "action_ephemeral_more"
-                }
-              ]
-            }
-          ]
-        )
+      def reply_interactive(message)
+        message.reply('This is interactive message', blocks: interactive_blocks)
+      end
+
+      def reply_interactive_as_ephemeral(message)
+        message.reply_as_ephemeral('This is ephemeral interactive message', blocks: interactive_blocks)
+      end
+
+      private
+
+      def interactive_blocks
+        [
+          {
+            "type": "section",
+            "text": { "type": "plain_text", "text": "Push any buttons" }
+          },
+          {
+            "type": "actions",
+            "elements": [
+              {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "Delete" },
+                "action_id": "action_delete"
+              },
+              {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "More message" },
+                "action_id": "action_more"
+              },
+              {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "More message (ephemeral)" },
+                "action_id": "action_more_ephemeral"
+              }
+            ]
+          }
+        ]
       end
     end
   end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -42,15 +42,22 @@ module Ruboty
           blocks: [
             {
               "type": "section",
-              "text": {
-                "type": "mrkdwn",
-                "text": "This is ephemeral message"
-              },
-              "accessory": {
-                "type": "button",
-                "text": { "type": "plain_text", "text": "OK" },
-                "action_id": "action_ephemeral_ok"
-              }
+              "text": { "type": "plain_text", "text": "This is ephemeral message" }
+            },
+            {
+              "type": "actions",
+              "elements": [
+                {
+                  "type": "button",
+                  "text": { "type": "plain_text", "text": "Delete" },
+                  "action_id": "action_ephemeral_delete"
+                },
+                {
+                  "type": "button",
+                  "text": { "type": "plain_text", "text": "More Message" },
+                  "action_id": "action_ephemeral_more"
+                }
+              ]
             }
           ]
         )

--- a/sample/ruboty-sample_plugin/lib/ruboty/sample_plugin.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/sample_plugin.rb
@@ -1,35 +1,3 @@
-require "ruboty/sample_plugin/version"
-
-module Ruboty
-  module Handlers
-    class SamplePlugin < Base
-      on(
-        /attachment/i,
-        name: 'reply_with_attachments',
-        description: 'reply with attachments',
-      )
-      on(
-        /file/i,
-        name: 'reply_with_file_attachment',
-        description: 'reply with a file attachment',
-      )
-
-      def reply_with_attachments(message)
-        message.reply('', attachments: [{
-          "text": "This is an attachment",
-          "id": 1,
-          "fallback": "This is an attachment's fallback"
-        }])
-      end
-
-      def reply_with_file_attachment(message)
-        message.reply('', file: {
-            path: 'sample_file',
-            title: 'sample_file',
-            content_type: 'text/plain'
-          }
-        )
-      end
-    end
-  end
-end
+require 'ruboty/sample_plugin/version'
+require 'ruboty/handlers/trigger'
+require 'ruboty/handlers/interactive'

--- a/sample/ruboty-sample_plugin/lib/ruboty/sample_plugin.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/sample_plugin.rb
@@ -1,3 +1,5 @@
 require 'ruboty/sample_plugin/version'
+
 require 'ruboty/handlers/trigger'
 require 'ruboty/handlers/interactive'
+require 'ruboty/handlers/events_api'


### PR DESCRIPTION
## What's this
Slackの Events API, および Interactive なイベントを Ruboty で扱えるようにします。
全てのイベントを網羅して試せてはおらず、実験的な実装を含みます。
また、 Interactive なイベントを扱うにあたり最低限必要になりそうな機能拡張をしています。

## Concept
Rubotyの通常のUsageでは、 `@ruboty ping` のように自分へのメンションが入ったテキストをコマンドとして検知します。
Slack App として扱うものが全て上記のようなパターンなのであればこれで十分なのですが、 `Events API` や インタラクティブUI に対する応答を行う場合、コマンドとして扱うのは厳しさがあります。

そこで、専用の Handler 共通クラスを用意しました。App開発者はそれを継承したクラスを作成することで任意の `Events API` や インタラクティブUI への処理を記載することができます。

Bot を開発する側の視点としては、下のファイルなどを参照するとわかりやすいかと思います。
[sample/ruboty-sample_plugin/lib/ruboty/handlers/events_api.rb](https://github.com/reproio/ruboty-slack_socket_mode/pull/3/files#diff-b8694b58cb45d7e331c54b4a1a1a64efce80f3c16e9a3bf5ef384fe75881b38c) 
[sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb](https://github.com/reproio/ruboty-slack_socket_mode/pull/3/files#diff-5493fee6da8f89bf30c47b8e860047e649aa388f37027ed6ab4cb012c1b5b02f)

## Implemented features
- Ephemeral message を post できるようにした
  - Handler からは `message.replyEphemeral` という形で使える
- Events API / Interactive を Ruboty Handler で取り扱えるようにした
  - それぞれ下記を継承してコントローラを作ることで扱える
    - `Ruboty::SlackSocketMode::Handlers::EventsApiHandler`
    - `Ruboty::SlackSocketMode::Handlers::InteractiveHandler`
- Interactive なメッセージを削除できるようにした
  - `message.delete` で削除できる

## Especially experimental features
- EventsApiHandler で呼ばれるメソッドの引数 `message` には現状、Slack Events API の Payload がそのまま渡ってくる。こちらは 極めて Experimental な状態である。

## Working image
![Untitled](https://user-images.githubusercontent.com/98291974/168021880-89bcb083-05d4-4ab6-8440-44e58df828a1.gif)

