### PR TITLE
Add update, state method

### DIFF
--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -83,11 +83,6 @@ module Ruboty
       end
 
       def update_interactive(response_url, text, blocks)
-        if text.nil? && blocks.nil?
-          Ruboty.logger.warn("#{self.class.name}: Cannot update message. Wrong number of arguments (expected text or blocks)")
-          return
-        end
-      
         params = { replace_original: "true" }
         params[:text] = text if text
         params[:blocks] = blocks if blocks

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -82,19 +82,15 @@ module Ruboty
         post_as_json(response_url, params)
       end
 
-      def update_interactive_block(response_url, block)
-        params = {
-          replace_original: "true",
-          blocks: block,
-        }
-        post_as_json(response_url, params)
-      end
-
-      def update_interactive_message(response_url, text)
-        params = {
-          replace_original: "true",
-          text: text,
-        }
+      def update_interactive(response_url, text, blocks)
+        if text.nil? && blocks.nil?
+          Ruboty.logger.warn("#{self.class.name}: Cannot update message. Wrong number of arguments (expected text or blocks)")
+          return
+        end
+      
+        params = { replace_original: "true" }
+        params[:text] = text if text
+        params[:blocks] = blocks if blocks
         post_as_json(response_url, params)
       end
 

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -25,18 +25,7 @@ module Ruboty
       end
 
       def say(message)
-<<<<<<< HEAD
         channel = message[:to]
-=======
-        # channel = message[:to]
-        channel = message[:original][:to]
-        if channel[0] == '#'
-          channel = resolve_channel_id(channel[1..-1])
-        end
-
-        return unless channel
-
->>>>>>> fix channel_id get flow
         args = {
           as_user: true,
           channel: channel
@@ -90,6 +79,22 @@ module Ruboty
 
       def delete_interactive(response_url)
         params = { delete_original: "true" }
+        post_as_json(response_url, params)
+      end
+
+      def update_interactive_block(response_url, block)
+        params = {
+          replace_original: "true",
+          blocks: block,
+        }
+        post_as_json(response_url, params)
+      end
+
+      def update_interactive_message(response_url, text)
+        params = {
+          replace_original: "true",
+          text: text,
+        }
         post_as_json(response_url, params)
       end
 

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -25,7 +25,18 @@ module Ruboty
       end
 
       def say(message)
+<<<<<<< HEAD
         channel = message[:to]
+=======
+        # channel = message[:to]
+        channel = message[:original][:to]
+        if channel[0] == '#'
+          channel = resolve_channel_id(channel[1..-1])
+        end
+
+        return unless channel
+
+>>>>>>> fix channel_id get flow
         args = {
           as_user: true,
           channel: channel

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -47,26 +47,13 @@ module Ruboty
         robot.delete_interactive(response_url)
       end
 
-      def update(text: nil, block: nil)
+      def update(text: nil, blocks: nil)
         response_url = @payload['response_url']
         unless response_url
           Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
           return
         end
-
-        if text.nil? && block.nil? || text && block
-          Ruboty.logger.warn("#{self.class.name}: Cannot update message. Wrong number of arguments (expected text or block)")
-          return
-        end
-
-        if text.is_a?(String)
-          robot.update_interactive_message(response_url, text)
-        elsif block.is_a?(Array)
-          robot.update_interactive_block(response_url, block)
-        else
-          Ruboty.logger.warn("#{self.class.name}: Cannot update message. This is not match argument type.")
-          return
-        end
+        robot.update_interactive(response_url, text, blocks)
       end
 
       def selected_value(block_id, action_id)

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -53,6 +53,12 @@ module Ruboty
           Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
           return
         end
+
+        if text.nil? && blocks.nil?
+          Ruboty.logger.warn("#{self.class.name}: Cannot update message. Wrong number of arguments (expected text or blocks)")
+          return
+        end
+
         robot.update_interactive(response_url, text, blocks)
       end
 
@@ -62,6 +68,7 @@ module Ruboty
           Ruboty.logger.warn("#{self.class.name}: Cannot get state. Block_id or action_id is not found")
           return
         end
+
         return case state['type']
         when 'static_select' then state.dig('selected_option', 'value')
         when 'multi_static_select' then state.dig('selected_options').map { |selected_option| selected_option['value'] }
@@ -75,6 +82,7 @@ module Ruboty
         when 'plain_text_input' then state.dig('value')
         else
           Ruboty.logger.warn("#{self.class.name}: Cannot get state. This is unsupported type.")
+          return nil
         end
       end
     end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -70,11 +70,12 @@ module Ruboty
       end
 
       def selected_value(block_id, action_id)
-        unless @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
+        selected_value = @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
+        unless selected_value
           Ruboty.logger.warn("#{self.class.name}: Cannot get selected value. Block_id or action_id is not found")
           return
         end
-        return @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
+        return selected_value
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -46,6 +46,32 @@ module Ruboty
 
         robot.delete_interactive(response_url)
       end
+
+      def update(text: nil, block: nil)
+        response_url = @payload['response_url']
+        unless response_url
+          Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
+          return
+        end
+
+        if text.nil? && block.nil? || text && block
+          Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
+          return
+        end
+
+        if text.is_a?(String)
+          robot.update_interactive_message(response_url, text)
+        elsif block.is_a?(Array)
+          robot.update_interactive_block(response_url, block)
+        else
+          Ruboty.logger.warn("#{self.class.name}: Cannot update message. This is not match argument type.")
+          return
+        end
+      end
+
+      def selected_value(block_id, action_id)
+        @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
+      end
     end
   end
 end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -55,7 +55,7 @@ module Ruboty
         end
 
         if text.nil? && block.nil? || text && block
-          Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
+          Ruboty.logger.warn("#{self.class.name}: Cannot update message. Wrong number of arguments (expected text or block)")
           return
         end
 
@@ -70,7 +70,11 @@ module Ruboty
       end
 
       def selected_value(block_id, action_id)
-        @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
+        unless @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
+          Ruboty.logger.warn("#{self.class.name}: Cannot get selected value. Block_id or action_id is not found")
+          return
+        end
+        return @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -6,8 +6,7 @@ module Ruboty
       include Mem
       delegate :add_reaction, to: :adapter
       delegate :delete_interactive, to: :adapter
-      delegate :update_interactive_message, to: :adapter
-      delegate :update_interactive_block, to: :adapter
+      delegate :update_interactive, to: :adapter
 
       def add_reaction(reaction, channel_id, timestamp)
         adapter.add_reaction(reaction, channel_id, timestamp)

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -6,6 +6,8 @@ module Ruboty
       include Mem
       delegate :add_reaction, to: :adapter
       delegate :delete_interactive, to: :adapter
+      delegate :update_interactive_message, to: :adapter
+      delegate :update_interactive_block, to: :adapter
 
       def add_reaction(reaction, channel_id, timestamp)
         adapter.add_reaction(reaction, channel_id, timestamp)

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,8 +1,8 @@
 module Ruboty::SlackSocketMode::Handlers
   class Interactive < InteractiveHandler
     on_interactive(
-      action_id: 'action_select',
-      name: 'select'
+      action_id: 'action_get_form',
+      name: 'get_form'
     )
     on_interactive(
       action_id: 'action_delete',
@@ -24,9 +24,31 @@ module Ruboty::SlackSocketMode::Handlers
       action_id: 'action_more_ephemeral',
       name: 'more_ephemeral'
     )
+    def get_form(message)
+      static_select = message.state(block_id: "static_select", action_id: "static_select-action")
+      multi_static_select = message.state(block_id: "multi_static_select", action_id: "multi_static_select-action")
+      multi_conversations_select = message.state(block_id: "multi_conversations_select", action_id: "multi_conversations_select-action")
+      timepicker = message.state(block_id: "timepicker", action_id: "timepicker-action")
+      datepicker = message.state(block_id: "datepicker", action_id: "datepicker-action")
+      checkboxes = message.state(block_id: "checkboxes", action_id: "checkboxes-action")
+      radio_buttons = message.state(block_id: "radio_buttons", action_id: "radio_buttons-action")
+      users_select = message.state(block_id: "users_select", action_id: "users_select-action")
+      multi_users_select = message.state(block_id: "multi_users_select", action_id: "multi_users_select-action")
+      plain_text_input = message.state(block_id: "plain_text_input", action_id: "plain_text_input-action")
 
-    def select(message)
-      message.reply(message.selected_value("select","action_select"))
+      text = <<~EOF
+      static_select : #{static_select}
+      multi_static_select : #{multi_static_select}
+      multi_conversations_select : #{multi_conversations_select}
+      timepicker : #{timepicker}
+      datepicker : #{datepicker}
+      checkboxes : #{checkboxes}
+      radio_buttons : #{radio_buttons}
+      users_select : #{users_select}
+      multi_users_select : #{multi_users_select}
+      plain_text_input : #{plain_text_input}
+      EOF
+      message.reply(text)
     end
 
     def delete(message)

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -9,6 +9,14 @@ module Ruboty::SlackSocketMode::Handlers
       name: 'more'
     )
     on_interactive(
+      action_id: 'action_update_message',
+      name: 'update_message'
+    )
+    on_interactive(
+      action_id: 'action_update_block',
+      name: 'update_block'
+    )
+    on_interactive(
       action_id: 'action_more_ephemeral',
       name: 'more_ephemeral'
     )
@@ -21,8 +29,56 @@ module Ruboty::SlackSocketMode::Handlers
       message.reply("Hello, #{message.from_name}!")
     end
 
+    def update_message(message)
+      message.update(text: "Update!")
+    end
+
+    def update_block(message)
+      message.update(block: interactive_blocks)
+    end
+
     def more_ephemeral(message)
       message.reply_as_ephemeral("Hello, #{message.from_name}!")
+    end
+
+    private
+    def interactive_blocks
+      [
+        {
+          "type": "section",
+          "text": { "type": "plain_text", "text": "Push any buttons (updated)" }
+        },
+        {
+          "type": "actions",
+          "elements": [
+            {
+              "type": "button",
+              "text": { "type": "plain_text", "text": "Delete" },
+              "action_id": "action_delete"
+            },
+            {
+              "type": "button",
+              "text": { "type": "plain_text", "text": "More message" },
+              "action_id": "action_more"
+            },
+            {
+              "type": "button",
+              "text": { "type": "plain_text", "text": "Update message" },
+              "action_id": "action_update_messagee"
+            },
+            {
+              "type": "button",
+              "text": { "type": "plain_text", "text": "Update block" },
+              "action_id": "action_update_block"
+            },
+            {
+              "type": "button",
+              "text": { "type": "plain_text", "text": "More message (ephemeral)" },
+              "action_id": "action_more_ephemeral"
+            }
+          ]
+        }
+      ]
     end
   end
 end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,6 +1,10 @@
 module Ruboty::SlackSocketMode::Handlers
   class Interactive < InteractiveHandler
     on_interactive(
+      action_id: 'action_select',
+      name: 'select'
+    )
+    on_interactive(
       action_id: 'action_delete',
       name: 'delete'
     )
@@ -20,6 +24,10 @@ module Ruboty::SlackSocketMode::Handlers
       action_id: 'action_more_ephemeral',
       name: 'more_ephemeral'
     )
+
+    def select(message)
+      message.reply(message.selected_value("select","action_select"))
+    end
 
     def delete(message)
       message.delete
@@ -46,7 +54,7 @@ module Ruboty::SlackSocketMode::Handlers
       [
         {
           "type": "section",
-          "text": { "type": "plain_text", "text": "Push any buttons (updated)" }
+          "text": { "type": "plain_text", "text": "Update! Push Delete button" }
         },
         {
           "type": "actions",
@@ -55,26 +63,6 @@ module Ruboty::SlackSocketMode::Handlers
               "type": "button",
               "text": { "type": "plain_text", "text": "Delete" },
               "action_id": "action_delete"
-            },
-            {
-              "type": "button",
-              "text": { "type": "plain_text", "text": "More message" },
-              "action_id": "action_more"
-            },
-            {
-              "type": "button",
-              "text": { "type": "plain_text", "text": "Update message" },
-              "action_id": "action_update_messagee"
-            },
-            {
-              "type": "button",
-              "text": { "type": "plain_text", "text": "Update block" },
-              "action_id": "action_update_block"
-            },
-            {
-              "type": "button",
-              "text": { "type": "plain_text", "text": "More message (ephemeral)" },
-              "action_id": "action_more_ephemeral"
             }
           ]
         }

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -9,16 +9,16 @@ module Ruboty::SlackSocketMode::Handlers
       name: 'delete'
     )
     on_interactive(
-      action_id: 'action_more',
-      name: 'more'
-    )
-    on_interactive(
       action_id: 'action_update_message',
       name: 'update_message'
     )
     on_interactive(
       action_id: 'action_update_block',
       name: 'update_block'
+    )
+    on_interactive(
+      action_id: 'action_more',
+      name: 'more'
     )
     on_interactive(
       action_id: 'action_more_ephemeral',
@@ -33,16 +33,16 @@ module Ruboty::SlackSocketMode::Handlers
       message.delete
     end
 
-    def more(message)
-      message.reply("Hello, #{message.from_name}!")
-    end
-
     def update_message(message)
       message.update(text: "Update!")
     end
 
     def update_block(message)
       message.update(block: interactive_blocks)
+    end
+
+    def more(message)
+      message.reply("Hello, #{message.from_name}!")
     end
 
     def more_ephemeral(message)

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -38,7 +38,7 @@ module Ruboty::SlackSocketMode::Handlers
     end
 
     def update_block(message)
-      message.update(block: interactive_blocks)
+      message.update(blocks: interactive_blocks)
     end
 
     def more(message)

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -75,9 +75,9 @@ module Ruboty
                 "action_id": "action_delete"
               },
               {
-              "type": "button",
-              "text": { "type": "plain_text", "text": "Update message" },
-              "action_id": "action_update_message"
+                "type": "button",
+                "text": { "type": "plain_text", "text": "Update message" },
+                "action_id": "action_update_message"
               },
               {
                 "type": "button",

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -23,6 +23,11 @@ module Ruboty
         name: 'reply_interactive_as_ephemeral',
         description: 'reply an interactive message as ephemeral',
       )
+      on(
+        /interactive_form\z/i,
+        name: 'reply_interactive_form',
+        description: 'reply an interactive message',
+      )
 
       def reply_with_attachments(message)
         message.reply('', attachments: [{
@@ -49,6 +54,10 @@ module Ruboty
         message.reply_as_ephemeral('This is ephemeral interactive message', blocks: interactive_blocks)
       end
 
+      def reply_interactive_form(message)
+        message.reply('This is interactive form', blocks: interactive_form)
+      end
+
       private
 
       def interactive_blocks
@@ -56,49 +65,6 @@ module Ruboty
           {
             "type": "section",
             "text": { "type": "plain_text", "text": "Push any buttons" }
-          },
-          {
-            "type": "section",
-            "block_id": "select",
-            "text": {
-              "type": "mrkdwn",
-              "text": "please select"
-            },
-            "accessory": {
-              "type": "static_select",
-              "placeholder": {
-                "type": "plain_text",
-                "text": "Select an item",
-                "emoji": true
-              },
-              "options": [
-                {
-                  "text": {
-                    "type": "plain_text",
-                    "text": "item-1",
-                    "emoji": true
-                  },
-                  "value": "item-1"
-                },
-                {
-                  "text": {
-                    "type": "plain_text",
-                    "text": "item-2",
-                    "emoji": true
-                  },
-                  "value": "item-2"
-                },
-                {
-                  "text": {
-                    "type": "plain_text",
-                    "text": "item-3",
-                    "emoji": true
-                  },
-                  "value": "item-3"
-                }
-              ],
-              "action_id": "action_select"
-            }
           },
           {
             "type": "actions",
@@ -129,6 +95,300 @@ module Ruboty
                 "action_id": "action_more_ephemeral"
               }
             ]
+          }
+        ]
+      end
+
+      def interactive_form
+        [
+          {
+            "type": "section",
+            "block_id": "static_select",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Pick an item from the dropdown list"
+            },
+            "accessory": {
+              "type": "static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select an item",
+                "emoji": true
+              },
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-0",
+                    "emoji": true
+                  },
+                  "value": "value-0"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-1",
+                    "emoji": true
+                  },
+                  "value": "value-1"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-2",
+                    "emoji": true
+                  },
+                  "value": "value-2"
+                }
+              ],
+              "action_id": "static_select-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "multi_static_select",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Test block with multi static select"
+            },
+            "accessory": {
+              "type": "multi_static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select options",
+                "emoji": true
+              },
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-0",
+                    "emoji": true
+                  },
+                  "value": "value-0"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-1",
+                    "emoji": true
+                  },
+                  "value": "value-1"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-2",
+                    "emoji": true
+                  },
+                  "value": "value-2"
+                }
+              ],
+              "action_id": "multi_static_select-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "multi_conversations_select",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Test block with multi conversations select"
+            },
+            "accessory": {
+              "type": "multi_conversations_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select conversations",
+                "emoji": true
+              },
+              "action_id": "multi_conversations_select-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "datepicker",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Pick a date for the deadline."
+            },
+            "accessory": {
+              "type": "datepicker",
+              "initial_date": "1990-04-28",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select a date",
+                "emoji": true
+              },
+              "action_id": "datepicker-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "checkboxes",
+            "text": {
+              "type": "mrkdwn",
+              "text": "This is a section block with checkboxes."
+            },
+            "accessory": {
+              "type": "checkboxes",
+              "options": [
+                {
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "value-0"
+                  },
+                  "description": {
+                    "type": "mrkdwn",
+                    "text": "discription"
+                  },
+                  "value": "value-0"
+                },
+                {
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "value-1"
+                  },
+                  "description": {
+                    "type": "mrkdwn",
+                    "text": "discription"
+                  },
+                  "value": "value-1"
+                },
+                {
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "value-2"
+                  },
+                  "description": {
+                    "type": "mrkdwn",
+                    "text": "description"
+                  },
+                  "value": "value-2"
+                }
+              ],
+              "action_id": "checkboxes-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "radio_buttons",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Section block with radio buttons"
+            },
+            "accessory": {
+              "type": "radio_buttons",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-0",
+                    "emoji": true
+                  },
+                  "value": "value-0"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-1",
+                    "emoji": true
+                  },
+                  "value": "value-1"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-2",
+                    "emoji": true
+                  },
+                  "value": "value-2"
+                }
+              ],
+              "action_id": "radio_buttons-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "timepicker",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Section block with a timepicker"
+            },
+            "accessory": {
+              "type": "timepicker",
+              "initial_time": "13:37",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select time",
+                "emoji": true
+              },
+              "action_id": "timepicker-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "users_select",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Test block with users select"
+            },
+            "accessory": {
+              "type": "users_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select a user",
+                "emoji": true
+              },
+              "action_id": "users_select-action"
+            }
+          },
+          {
+            "type": "input",
+            "block_id": "multi_users_select",
+            "element": {
+              "type": "multi_users_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select users",
+                "emoji": true
+              },
+              "action_id": "multi_users_select-action"
+            },
+            "label": {
+              "type": "plain_text",
+              "text": "Label",
+              "emoji": true
+            }
+          },
+          {
+            "type": "input",
+            "block_id": "plain_text_input",
+            "element": {
+              "type": "plain_text_input",
+              "action_id": "plain_text_input-action"
+            },
+            "label": {
+              "type": "plain_text",
+              "text": "Label",
+              "emoji": true
+            }
+          },
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "This is a section block with a button."
+            },
+            "accessory": {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "text": "get_form",
+                "emoji": true
+              },
+              "value": "get_form",
+              "action_id": "action_get_form"
+            }
           }
         ]
       end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -109,11 +109,6 @@ module Ruboty
                 "action_id": "action_delete"
               },
               {
-                "type": "button",
-                "text": { "type": "plain_text", "text": "More message" },
-                "action_id": "action_more"
-              },
-              {
               "type": "button",
               "text": { "type": "plain_text", "text": "Update message" },
               "action_id": "action_update_message"
@@ -122,6 +117,11 @@ module Ruboty
                 "type": "button",
                 "text": { "type": "plain_text", "text": "Update block" },
                 "action_id": "action_update_block"
+              },
+              {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "More message" },
+                "action_id": "action_more"
               },
               {
                 "type": "button",

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -58,6 +58,49 @@ module Ruboty
             "text": { "type": "plain_text", "text": "Push any buttons" }
           },
           {
+            "type": "section",
+            "block_id": "select",
+            "text": {
+              "type": "mrkdwn",
+              "text": "please select"
+            },
+            "accessory": {
+              "type": "static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select an item",
+                "emoji": true
+              },
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "item-1",
+                    "emoji": true
+                  },
+                  "value": "item-1"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "item-2",
+                    "emoji": true
+                  },
+                  "value": "item-2"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "item-3",
+                    "emoji": true
+                  },
+                  "value": "item-3"
+                }
+              ],
+              "action_id": "action_select"
+            }
+          },
+          {
             "type": "actions",
             "elements": [
               {

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -71,6 +71,16 @@ module Ruboty
                 "action_id": "action_more"
               },
               {
+              "type": "button",
+              "text": { "type": "plain_text", "text": "Update message" },
+              "action_id": "action_update_message"
+              },
+              {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "Update block" },
+                "action_id": "action_update_block"
+              },
+              {
                 "type": "button",
                 "text": { "type": "plain_text", "text": "More message (ephemeral)" },
                 "action_id": "action_more_ephemeral"


### PR DESCRIPTION
## What's this
rubotyでSlackのチャットのupdate及びinteractiveなUIで選択した値を取得できるようにします。

現状ではコメントの削除のみできており、今後interactiveなUIを実装する上で必要となる以下を可能にしました。
- botが送ったメッセージのupdate
- 選択された値の取得

## 機能の説明
### message.update(text, block)
textとblockのキーワード引数を受け取り、両方が指定された場合はblockが動作します。
メッセージを送ったtext,blockに編集します。

```
# example
message.update(text: "Hello!!!")
```
動作例
![update](https://user-images.githubusercontent.com/98137262/168732846-474a132d-327d-4097-9328-78ed9846ab8c.gif)

### message.state(block_id:, action_id:)
block内で設定したblock_idとaction_idを引数として渡すことで動作します。
interactiveなUI内で選択した(入力した)値を取得します。
今回対応しているType
- static_select
- multi_static_select
- multi_conversations_select
- datepicker
- checkboxes
- radio_buttons
- timepicker
- users_select
- multi_users_select
- plain_text_input

```
# example
message.state(block_id: "block_id", action_id: "action_id")
```

動作例
![selected_value](https://user-images.githubusercontent.com/98137262/168733078-63614f04-5b0f-43e8-871d-490a196e41fe.gif)