### PR TITLE
Enable to handle interactive messages

### DIFF
--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -26,12 +26,6 @@ module Ruboty
 
       def say(message)
         channel = message[:to]
-        if channel[0] == '#'
-          channel = resolve_channel_id(channel[1..-1])
-        end
-
-        return unless channel
-
         args = {
           as_user: true,
           channel: channel
@@ -72,7 +66,7 @@ module Ruboty
         end
 
         if message[:ephemeral]
-          args.merge!(user: message[:original][:user]['id'])
+          args.merge!(user: message[:user_id])
           client.chat_postEphemeral(args)
         else
           client.chat_postMessage(args)

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -2,8 +2,10 @@ require 'cgi'
 require 'time'
 require 'json'
 require 'slack'
-require 'ruboty/adapters/base'
 require 'faraday'
+
+require 'ruboty/adapters/base'
+require 'ruboty/slack_socket_mode/interactive_message'
 
 module Ruboty
   module Adapters
@@ -137,8 +139,8 @@ module Ruboty
       end
 
       def handle_interactive(data)
-        # TODO: add event handling for Block Kit buttons
-        robot.receive_interactive(data['type'], data)
+        interactive_message = Ruboty::SlackSocketMode::InteractiveMessage.new(robot, data)
+        robot.receive_interactive(interactive_message)
       end
 
       def connect

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -92,11 +92,10 @@ module Ruboty
       private
 
       def post_as_json(url, params)
-        uri = URI.parse(url)
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = uri.scheme === "https"
-        headers = { "Content-Type" => "application/json" }
-        http.post(uri.path, params.to_json, headers)
+        Faraday.new(url).post do |connection|
+          connection.headers["Content-Type"] = "application/json"
+          connection.body = params.to_json
+        end
       end
 
       def init

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -47,14 +47,14 @@ module Ruboty
           return
         end
 
-        if message[:attachments] && !message[:attachments].empty?
+        if !message.fetch(:attachments, []).empty?
           args.merge!(
             text: message[:code] ? "```\n#{message[:body]}\n```" : message[:body],
             parse: message[:parse] || 'full',
             unfurl_links: true,
             attachments: message[:attachments].to_json
           )
-        elsif message[:blocks] && !message[:blocks].empty?
+        elsif !message.fetch(:blocks, []).empty?
           args.merge!(
             blocks: message[:blocks],
           )

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -83,11 +83,6 @@ module Ruboty
       end
 
       def update_interactive(response_url, text, blocks)
-        if text.nil? && blocks.nil?
-          Ruboty.logger.warn("#{self.class.name}: Cannot update message. Wrong number of arguments (expected text or blocks)")
-          return
-        end
-      
         params = { replace_original: "true" }
         params[:text] = text if text
         params[:blocks] = blocks if blocks

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -82,19 +82,15 @@ module Ruboty
         post_as_json(response_url, params)
       end
 
-      def update_interactive_block(response_url, block)
-        params = {
-          replace_original: "true",
-          blocks: block,
-        }
-        post_as_json(response_url, params)
-      end
-
-      def update_interactive_message(response_url, text)
-        params = {
-          replace_original: "true",
-          text: text,
-        }
+      def update_interactive(response_url, text, blocks)
+        if text.nil? && blocks.nil?
+          Ruboty.logger.warn("#{self.class.name}: Cannot update message. Wrong number of arguments (expected text or blocks)")
+          return
+        end
+      
+        params = { replace_original: "true" }
+        params[:text] = text if text
+        params[:blocks] = blocks if blocks
         post_as_json(response_url, params)
       end
 

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -82,10 +82,13 @@ module Ruboty
         post_as_json(response_url, params)
       end
 
-      def update_interactive(response_url, text, blocks)
-        params = { replace_original: "true" }
-        params[:text] = text if text
-        params[:blocks] = blocks if blocks
+      def update_message(response_url, text)
+        params = { replace_original: "true", text: text }
+        post_as_json(response_url, params)
+      end
+
+      def update_blocks(response_url, blocks)
+        params = { replace_original: "true", blocks: blocks }
         post_as_json(response_url, params)
       end
 

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -82,7 +82,7 @@ module Ruboty
         post_as_json(response_url, params)
       end
 
-      def update_message(response_url, text)
+      def update(response_url, text)
         params = { replace_original: "true", text: text }
         post_as_json(response_url, params)
       end

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -25,18 +25,7 @@ module Ruboty
       end
 
       def say(message)
-<<<<<<< HEAD
         channel = message[:to]
-=======
-        # channel = message[:to]
-        channel = message[:original][:to]
-        if channel[0] == '#'
-          channel = resolve_channel_id(channel[1..-1])
-        end
-
-        return unless channel
-
->>>>>>> fix channel_id get flow
         args = {
           as_user: true,
           channel: channel
@@ -90,6 +79,22 @@ module Ruboty
 
       def delete_interactive(response_url)
         params = { delete_original: "true" }
+        post_as_json(response_url, params)
+      end
+
+      def update_interactive_block(response_url, block)
+        params = {
+          replace_original: "true",
+          blocks: block,
+        }
+        post_as_json(response_url, params)
+      end
+
+      def update_interactive_message(response_url, text)
+        params = {
+          replace_original: "true",
+          text: text,
+        }
         post_as_json(response_url, params)
       end
 

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -118,20 +118,27 @@ module Ruboty
             # auto reconnecting works if SLACK_AUTO_RECONNECT configured.
           when 'events_api'
             event = data.dig('payload', 'event')
+            handle_events_api(data['payload']['event'])
+
             method_name = :"on_#{event['type']}"
-            if respond_to?(method_name, true)
-              send(method_name, event)
-            else
-              Ruboty.logger.warn("#{self.class.name}: Received unsupported events_api type: '#{event['type']}'.")
-            end
+            send(method_name, event) if respond_to?(method_name, true)
           when 'slash_commands'
             # TODO: add event handling for Slash commands
           when 'interactive'
-            interactive(data['payload'])
+            handle_interactive(data['payload'])
           else
             Ruboty.logger.warn("#{self.class.name}: Received unsupported data type: '#{data['type']}'.")
           end
         end
+      end
+
+      def handle_events_api(data)
+        robot.receive_events_api(data['type'], data)
+      end
+
+      def handle_interactive(data)
+        # TODO: add event handling for Block Kit buttons
+        robot.receive_interactive(data['type'], data)
       end
 
       def connect

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -25,7 +25,18 @@ module Ruboty
       end
 
       def say(message)
+<<<<<<< HEAD
         channel = message[:to]
+=======
+        # channel = message[:to]
+        channel = message[:original][:to]
+        if channel[0] == '#'
+          channel = resolve_channel_id(channel[1..-1])
+        end
+
+        return unless channel
+
+>>>>>>> fix channel_id get flow
         args = {
           as_user: true,
           channel: channel

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -212,15 +212,15 @@ module Ruboty
         action = data['actions'].first
         message_info = {
           from: data['channel'],
-          from_name: data['user']['name'],
-          to: data['channel']['id'],
-          channel: data['channel']['id'],
+          from_name: data.dig('user', 'name'),
+          to: data.dig('channel', 'id'),
+          channel: data.dig('channel', 'id'),
           user: data['user'],
           url: data["response_url"],
           action_value: action['value'],
           ts: action['action_ts'],
           time: Time.at(action['action_ts'].to_f),
-          body: "#{ENV['RUBOTY_NAME']} slack_interactive::#{action['action_id']}",
+          body: "#{ruboty_name} slack_interactive::#{action['action_id']}",
           data: data,
         }
         robot.receive(message_info)
@@ -432,6 +432,10 @@ module Ruboty
 
       def slack_auto_reconnect
         ENV['SLACK_AUTO_RECONNECT']
+      end
+
+      def ruboty_name
+        ENV['RUBOTY_NAME']
       end
     end
   end

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -211,24 +211,6 @@ module Ruboty
       # ref: https://api.slack.com/events/app_mention
       alias_method :on_message, :on_app_mention
 
-      def interactive(data)
-        action = data['actions'].first
-        message_info = {
-          from: data['channel'],
-          from_name: data.dig('user', 'name'),
-          to: data.dig('channel', 'id'),
-          channel: data.dig('channel', 'id'),
-          user: data['user'],
-          url: data["response_url"],
-          action_value: action['value'],
-          ts: action['action_ts'],
-          time: Time.at(action['action_ts'].to_f),
-          body: "#{ruboty_name} slack_interactive::#{action['action_id']}",
-          data: data,
-        }
-        robot.receive(message_info)
-      end
-
       def on_channel_change(data)
         make_channels_cache
       end

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -82,13 +82,10 @@ module Ruboty
         post_as_json(response_url, params)
       end
 
-      def update(response_url, text)
-        params = { replace_original: "true", text: text }
-        post_as_json(response_url, params)
-      end
-
-      def update_blocks(response_url, blocks)
-        params = { replace_original: "true", blocks: blocks }
+      def update_interactive(response_url, text, blocks)
+        params = { replace_original: "true" }
+        params[:text] = text if text
+        params[:blocks] = blocks if blocks
         post_as_json(response_url, params)
       end
 

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -118,7 +118,7 @@ module Ruboty
             # auto reconnecting works if SLACK_AUTO_RECONNECT configured.
           when 'events_api'
             event = data.dig('payload', 'event')
-            handle_events_api(data['payload']['event'])
+            handle_events_api(event)
 
             method_name = :"on_#{event['type']}"
             send(method_name, event) if respond_to?(method_name, true)

--- a/lib/ruboty/adapters/slack_socket_mode.rb
+++ b/lib/ruboty/adapters/slack_socket_mode.rb
@@ -77,16 +77,20 @@ module Ruboty
         client.reactions_add(name: reaction, channel: channel_id, timestamp: timestamp)
       end
 
-      def delete_ephemeral_message(response_url)
-        uri = URI.parse(response_url)
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = uri.scheme === "https"
+      def delete_interactive(response_url)
         params = { delete_original: "true" }
-        headers = { "Content-Type" => "application/json" }
-        http.post(uri.path, params.to_json, headers)
+        post_as_json(response_url, params)
       end
 
       private
+
+      def post_as_json(url, params)
+        uri = URI.parse(url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme === "https"
+        headers = { "Content-Type" => "application/json" }
+        http.post(uri.path, params.to_json, headers)
+      end
 
       def init
         response = client.auth_test

--- a/lib/ruboty/slack_socket_mode.rb
+++ b/lib/ruboty/slack_socket_mode.rb
@@ -1,5 +1,11 @@
 require 'ruboty/slack_socket_mode/version'
-require 'ruboty/slack_socket_mode/client'
-require 'ruboty/adapters/slack_socket_mode'
+
+require 'ruboty/slack_socket_mode/handlers'
+require 'ruboty/slack_socket_mode/handlers/events_api_handler'
+require 'ruboty/slack_socket_mode/handlers/interactive_handler'
+
 require 'ruboty/slack_socket_mode/robot'
 require 'ruboty/slack_socket_mode/message'
+require 'ruboty/slack_socket_mode/client'
+
+require 'ruboty/adapters/slack_socket_mode'

--- a/lib/ruboty/slack_socket_mode/client.rb
+++ b/lib/ruboty/slack_socket_mode/client.rb
@@ -27,6 +27,8 @@ module Ruboty
           when :text
             Ruboty.logger.debug("#{Client.name}: Received text message: #{message.data}")
             data = JSON.parse(message.data)
+            Ruboty.logger.debug("#{Client.name}: Received text message")
+            Ruboty.logger.debug(message.data)
 
             # ACK response for SocketMode
             # ref: https://api.slack.com/apis/connections/socket-implement#acknowledge

--- a/lib/ruboty/slack_socket_mode/client.rb
+++ b/lib/ruboty/slack_socket_mode/client.rb
@@ -25,10 +25,8 @@ module Ruboty
           when :pong
             Ruboty.logger.debug("#{Client.name}: Received pong message")
           when :text
-            Ruboty.logger.debug("#{Client.name}: Received text message: #{message.data}")
             data = JSON.parse(message.data)
-            Ruboty.logger.debug("#{Client.name}: Received text message")
-            Ruboty.logger.debug(message.data)
+            Ruboty.logger.debug("#{Client.name}: Received text message: #{data}")
 
             # ACK response for SocketMode
             # ref: https://api.slack.com/apis/connections/socket-implement#acknowledge

--- a/lib/ruboty/slack_socket_mode/events_api_command.rb
+++ b/lib/ruboty/slack_socket_mode/events_api_command.rb
@@ -1,0 +1,12 @@
+module Ruboty
+  module SlackSocketMode
+    class EventsApiCommand
+      attr_reader :event_type, :method_name
+
+      def initialize(event_type, method_name)
+        @event_type = event_type
+        @method_name = method_name
+      end
+    end
+  end
+end

--- a/lib/ruboty/slack_socket_mode/handlers.rb
+++ b/lib/ruboty/slack_socket_mode/handlers.rb
@@ -15,11 +15,6 @@ module Ruboty
           []
         end
         memoize :interactive
-
-        def slash_commands
-          []
-        end
-        memoize :slash_commands
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/handlers.rb
+++ b/lib/ruboty/slack_socket_mode/handlers.rb
@@ -3,18 +3,11 @@ require 'ruboty'
 module Ruboty
   module SlackSocketMode
     module Handlers
+      @events_api = []
+      @interactive = []
+
       class << self
-        include Mem
-
-        def events_api
-          []
-        end
-        memoize :events_api
-
-        def interactive
-          []
-        end
-        memoize :interactive
+        attr_accessor :events_api, :interactive
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/handlers.rb
+++ b/lib/ruboty/slack_socket_mode/handlers.rb
@@ -1,0 +1,26 @@
+require 'ruboty'
+
+module Ruboty
+  module SlackSocketMode
+    module Handlers
+      class << self
+        include Mem
+
+        def events_api
+          []
+        end
+        memoize :events_api
+
+        def interactive
+          []
+        end
+        memoize :interactive
+
+        def slash_commands
+          []
+        end
+        memoize :slash_commands
+      end
+    end
+  end
+end

--- a/lib/ruboty/slack_socket_mode/handlers.rb
+++ b/lib/ruboty/slack_socket_mode/handlers.rb
@@ -7,7 +7,7 @@ module Ruboty
       @interactive = []
 
       class << self
-        attr_accessor :events_api, :interactive
+        attr_reader :events_api, :interactive
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
@@ -3,6 +3,15 @@ require "ostruct"
 module Ruboty
   module SlackSocketMode
     module Handlers
+      class EventsApiAction
+        attr_reader :event_type, :method_name
+
+        def initialize(event_type, method_name)
+          @event_type = event_type
+          @method_name = method_name
+        end
+      end
+
       class EventsApiHandler
         class << self
           include Mem
@@ -11,8 +20,8 @@ module Ruboty
             Ruboty::SlackSocketMode::Handlers.events_api << child
           end
 
-          def on(event_type:, name:)
-            actions << OpenStruct.new(event_type: event_type, method_name: name)
+          def on_event(event_type:, name:)
+            actions << EventsApiAction.new(event_type, name)
           end
 
           def actions
@@ -21,13 +30,10 @@ module Ruboty
           memoize :actions
         end
 
-        include Env::Validatable
-
         attr_reader :robot
 
         def initialize(robot)
           @robot = robot
-          validate!
         end
       end
     end

--- a/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
@@ -1,17 +1,8 @@
-require "ostruct"
+require 'ruboty/slack_socket_mode/events_api_command'
 
 module Ruboty
   module SlackSocketMode
     module Handlers
-      class EventsApiAction
-        attr_reader :event_type, :method_name
-
-        def initialize(event_type, method_name)
-          @event_type = event_type
-          @method_name = method_name
-        end
-      end
-
       class EventsApiHandler
         class << self
           include Mem
@@ -21,13 +12,13 @@ module Ruboty
           end
 
           def on_event(event_type:, name:)
-            actions << EventsApiAction.new(event_type, name)
+            commands << Ruboty::SlackSocketMode::EventsApiCommand.new(event_type, name)
           end
 
-          def actions
+          def commands
             []
           end
-          memoize :actions
+          memoize :commands
         end
 
         attr_reader :robot

--- a/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
@@ -5,20 +5,16 @@ module Ruboty
     module Handlers
       class EventsApiHandler
         class << self
-          include Mem
+          attr_reader :commands
 
           def inherited(child)
             Ruboty::SlackSocketMode::Handlers.events_api << child
           end
 
           def on_event(event_type:, name:)
-            commands << Ruboty::SlackSocketMode::EventsApiCommand.new(event_type, name)
+            @commands ||= []
+            @commands << Ruboty::SlackSocketMode::EventsApiCommand.new(event_type, name)
           end
-
-          def commands
-            []
-          end
-          memoize :commands
         end
 
         attr_reader :robot

--- a/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/events_api_handler.rb
@@ -1,0 +1,35 @@
+require "ostruct"
+
+module Ruboty
+  module SlackSocketMode
+    module Handlers
+      class EventsApiHandler
+        class << self
+          include Mem
+
+          def inherited(child)
+            Ruboty::SlackSocketMode::Handlers.events_api << child
+          end
+
+          def on(event_type:, name:)
+            actions << OpenStruct.new(event_type: event_type, method_name: name)
+          end
+
+          def actions
+            []
+          end
+          memoize :actions
+        end
+
+        include Env::Validatable
+
+        attr_reader :robot
+
+        def initialize(robot)
+          @robot = robot
+          validate!
+        end
+      end
+    end
+  end
+end

--- a/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
@@ -1,16 +1,8 @@
-require "ostruct"
+require 'ruboty/slack_socket_mode/interactive_command'
 
 module Ruboty
   module SlackSocketMode
     module Handlers
-      class InteractiveAction
-        attr_reader :action_id, :method_name
-
-        def initialize(action_id, method_name)
-          @action_id = action_id
-          @method_name = method_name
-        end
-      end
 
       class InteractiveHandler
         class << self
@@ -21,13 +13,13 @@ module Ruboty
           end
 
           def on_interactive(action_id:, name:)
-            actions << InteractiveAction.new(action_id, name)
+            commands << Ruboty::SlackSocketMode::InteractiveCommand.new(action_id, name)
           end
 
-          def actions
+          def commands
             []
           end
-          memoize :actions
+          memoize :commands
         end
 
         attr_reader :robot

--- a/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
@@ -6,20 +6,16 @@ module Ruboty
 
       class InteractiveHandler
         class << self
-          include Mem
+          attr_reader :commands
 
           def inherited(child)
             Ruboty::SlackSocketMode::Handlers.interactive << child
           end
 
           def on_interactive(action_id:, name:)
-            commands << Ruboty::SlackSocketMode::InteractiveCommand.new(action_id, name)
+            @commands ||= []
+            @commands << Ruboty::SlackSocketMode::InteractiveCommand.new(action_id, name)
           end
-
-          def commands
-            []
-          end
-          memoize :commands
         end
 
         attr_reader :robot

--- a/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
@@ -3,6 +3,15 @@ require "ostruct"
 module Ruboty
   module SlackSocketMode
     module Handlers
+      class InteractiveAction
+        attr_reader :action_id, :method_name
+
+        def initialize(action_id, method_name)
+          @action_id = action_id
+          @method_name = method_name
+        end
+      end
+
       class InteractiveHandler
         class << self
           include Mem
@@ -11,8 +20,8 @@ module Ruboty
             Ruboty::SlackSocketMode::Handlers.interactive << child
           end
 
-          def on(action_id:, name:)
-            actions << OpenStruct.new(action_id: action_id, method_name: name)
+          def on_interactive(action_id:, name:)
+            actions << InteractiveAction.new(action_id, name)
           end
 
           def actions
@@ -21,13 +30,10 @@ module Ruboty
           memoize :actions
         end
 
-        include Env::Validatable
-
         attr_reader :robot
 
         def initialize(robot)
           @robot = robot
-          validate!
         end
       end
     end

--- a/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
+++ b/lib/ruboty/slack_socket_mode/handlers/interactive_handler.rb
@@ -1,0 +1,35 @@
+require "ostruct"
+
+module Ruboty
+  module SlackSocketMode
+    module Handlers
+      class InteractiveHandler
+        class << self
+          include Mem
+
+          def inherited(child)
+            Ruboty::SlackSocketMode::Handlers.interactive << child
+          end
+
+          def on(action_id:, name:)
+            actions << OpenStruct.new(action_id: action_id, method_name: name)
+          end
+
+          def actions
+            []
+          end
+          memoize :actions
+        end
+
+        include Env::Validatable
+
+        attr_reader :robot
+
+        def initialize(robot)
+          @robot = robot
+          validate!
+        end
+      end
+    end
+  end
+end

--- a/lib/ruboty/slack_socket_mode/interactive_command.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_command.rb
@@ -1,0 +1,12 @@
+module Ruboty
+  module SlackSocketMode
+    class InteractiveCommand
+      attr_reader :action_id, :method_name
+
+      def initialize(action_id, method_name)
+        @action_id = action_id
+        @method_name = method_name
+      end
+    end
+  end
+end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -47,26 +47,13 @@ module Ruboty
         robot.delete_interactive(response_url)
       end
 
-      def update(text: nil, block: nil)
+      def update(text: nil, blocks: nil)
         response_url = @payload['response_url']
         unless response_url
           Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
           return
         end
-
-        if text.nil? && block.nil? || text && block
-          Ruboty.logger.warn("#{self.class.name}: Cannot update message. Wrong number of arguments (expected text or block)")
-          return
-        end
-
-        if text.is_a?(String)
-          robot.update_interactive_message(response_url, text)
-        elsif block.is_a?(Array)
-          robot.update_interactive_block(response_url, block)
-        else
-          Ruboty.logger.warn("#{self.class.name}: Cannot update message. This is not match argument type.")
-          return
-        end
+        robot.update_interactive(response_url, text, blocks)
       end
 
       def selected_value(block_id, action_id)

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -12,11 +12,15 @@ module Ruboty
       end
 
       def from
-        @payload.dig("channel", "id")
+        payload.dig("channel", "id")
+      end
+
+      def from_name
+        payload.dig("user", "name")
       end
 
       def user_id
-        @payload.dig("user", "id")
+        payload.dig("user", "id")
       end
 
       def reply(body, options = {})
@@ -25,7 +29,7 @@ module Ruboty
           return
         end
 
-        attributes = { body: body, to: from, original: @payload }.merge(options)
+        attributes = { body: body, to: from, original: payload }.merge(options)
         robot.say(attributes)
       end
 
@@ -34,11 +38,11 @@ module Ruboty
       end
 
       def delete
-        unless @payload['response_url']
+        unless payload['response_url']
           Ruboty.logger.warn("#{self.class.name}: Cannot delete message. This is not an ephemeral message.")
           return
         end
-        @robot.delete_ephemeral_message(@payload['response_url'])
+        @robot.delete_ephemeral_message(payload['response_url'])
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -55,19 +55,24 @@ module Ruboty
         robot.delete_interactive(response_url)
       end
 
-      def update(text: nil, blocks: nil)
+      def update_message(text)
         response_url = @payload['response_url']
         unless response_url
           Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
           return
         end
 
-        if text.nil? && blocks.nil?
-          Ruboty.logger.warn("#{self.class.name}: Cannot update message. Wrong number of arguments (expected text or blocks)")
+        robot.update_message(response_url, text)
+      end
+
+      def update_blocks(blocks)
+        response_url = @payload['response_url']
+        unless response_url
+          Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
           return
         end
 
-        robot.update_interactive(response_url, text, blocks)
+        robot.update_blocks(response_url, blocks)
       end
 
       def state(block_id:, action_id:)

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -1,0 +1,27 @@
+require 'ruboty/message'
+
+module Ruboty
+  module SlackSocketMode
+    class InteractiveMessage
+      attr_reader :action_id, :payload
+
+      def initialize(robot, payload)
+        @robot = robot
+        @payload = payload
+        @action_id = payload['actions'].first['action_id']
+      end
+
+      def delete
+        unless @payload['response_url']
+          Ruboty.logger.warn("#{self.class.name}: Cannot delete message. This is not an ephemeral message.")
+          return
+        end
+        @robot.delete_ephemeral_message(@payload['response_url'])
+      end
+
+      private
+
+      attr_reader :robot
+    end
+  end
+end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -12,15 +12,15 @@ module Ruboty
       end
 
       def from
-        payload.dig("channel", "id")
+        @payload.dig("channel", "id")
       end
 
       def from_name
-        payload.dig("user", "name")
+        @payload.dig("user", "name")
       end
 
       def user_id
-        payload.dig("user", "id")
+        @payload.dig("user", "id")
       end
 
       def reply(body, options = {})
@@ -29,7 +29,7 @@ module Ruboty
           return
         end
 
-        attributes = { body: body, to: from, original: payload }.merge(options)
+        attributes = { body: body, to: from, original: @payload }.merge(options)
         robot.say(attributes)
       end
 
@@ -38,7 +38,7 @@ module Ruboty
       end
 
       def delete
-        response_url = payload['response_url']
+        response_url = @payload['response_url']
         unless response_url
           Ruboty.logger.warn("#{self.class.name}: Cannot delete message. This message does not contain response_url in payload.")
           return

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -53,6 +53,12 @@ module Ruboty
           Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
           return
         end
+
+        if text.nil? && blocks.nil?
+          Ruboty.logger.warn("#{self.class.name}: Cannot update message. Wrong number of arguments (expected text or blocks)")
+          return
+        end
+
         robot.update_interactive(response_url, text, blocks)
       end
 
@@ -62,6 +68,7 @@ module Ruboty
           Ruboty.logger.warn("#{self.class.name}: Cannot get state. Block_id or action_id is not found")
           return
         end
+
         return case state['type']
         when 'static_select' then state.dig('selected_option', 'value')
         when 'multi_static_select' then state.dig('selected_options').map { |selected_option| selected_option['value'] }
@@ -75,6 +82,7 @@ module Ruboty
         when 'plain_text_input' then state.dig('value')
         else
           Ruboty.logger.warn("#{self.class.name}: Cannot get state. This is unsupported type.")
+          return nil
         end
       end
     end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -3,12 +3,34 @@ require 'ruboty/message'
 module Ruboty
   module SlackSocketMode
     class InteractiveMessage
-      attr_reader :action_id, :payload
+      attr_reader :robot, :action_id, :payload
 
       def initialize(robot, payload)
         @robot = robot
         @payload = payload
         @action_id = payload['actions'].first['action_id']
+      end
+
+      def from
+        @payload.dig("channel", "id")
+      end
+
+      def user_id
+        @payload.dig("user", "id")
+      end
+
+      def reply(body, options = {})
+        unless from
+          Ruboty.logger.warn("#{self.class.name}: Cannot reply message. Destination channel is not found.")
+          return
+        end
+
+        attributes = { body: body, to: from, original: @payload }.merge(options)
+        robot.say(attributes)
+      end
+
+      def reply_ephemeral(body, options = {})
+        reply(body, options.merge(ephemeral: true, user_id: user_id))
       end
 
       def delete
@@ -18,10 +40,6 @@ module Ruboty
         end
         @robot.delete_ephemeral_message(@payload['response_url'])
       end
-
-      private
-
-      attr_reader :robot
     end
   end
 end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -70,11 +70,12 @@ module Ruboty
       end
 
       def selected_value(block_id, action_id)
-        unless @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
+        selected_value = @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
+        unless selected_value
           Ruboty.logger.warn("#{self.class.name}: Cannot get selected value. Block_id or action_id is not found")
           return
         end
-        return @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
+        return selected_value
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -76,9 +76,15 @@ module Ruboty
       end
 
       def state(block_id:, action_id:)
-        state = @payload.dig('state', 'values', block_id, action_id)
+        block = @payload.dig('state', 'values', block_id)
+        unless block
+          Ruboty.logger.warn("#{self.class.name}: Cannot get state. block_id: #{block_id} is not found")
+          return
+        end
+
+        state = block[action_id]
         unless state
-          Ruboty.logger.warn("#{self.class.name}: Cannot get state. block_id: #{block_id} or action_id: #{action_id} is not found")
+          Ruboty.logger.warn("#{self.class.name}: Cannot get state. action_id: #{action_id} is not found")
           return
         end
 
@@ -95,7 +101,7 @@ module Ruboty
         when 'plain_text_input' then state.dig('value')
         else
           Ruboty.logger.warn("#{self.class.name}: Cannot get state. This is unsupported type: #{state['type']}.")
-          return nil
+          return
         end
       end
     end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -55,20 +55,20 @@ module Ruboty
         robot.delete_interactive(response_url)
       end
 
-      def update_message(text)
+      def update(text)
         response_url = @payload['response_url']
         unless response_url
           Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
           return
         end
 
-        robot.update_message(response_url, text)
+        robot.update(response_url, text)
       end
 
       def update_blocks(blocks)
         response_url = @payload['response_url']
         unless response_url
-          Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
+          Ruboty.logger.warn("#{self.class.name}: Cannot update blocks. This blocks does not contain response_url in payload.")
           return
         end
 
@@ -78,7 +78,7 @@ module Ruboty
       def state(block_id:, action_id:)
         state = @payload.dig('state', 'values', block_id, action_id)
         unless state
-          Ruboty.logger.warn("#{self.class.name}: Cannot get state. Block_id or action_id is not found")
+          Ruboty.logger.warn("#{self.class.name}: Cannot get state. block_id: #{block_id} or action_id: #{action_id} is not found")
           return
         end
 
@@ -94,7 +94,7 @@ module Ruboty
         when 'datepicker' then state.dig('selected_date')
         when 'plain_text_input' then state.dig('value')
         else
-          Ruboty.logger.warn("#{self.class.name}: Cannot get state. This is unsupported type.")
+          Ruboty.logger.warn("#{self.class.name}: Cannot get state. This is unsupported type: #{state['type']}.")
           return nil
         end
       end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -8,7 +8,7 @@ module Ruboty
       def initialize(robot, payload)
         @robot = robot
         @payload = payload
-        @action_id = payload['actions'].first['action_id']
+        @action_id = payload.dig('actions', 0, 'action_id')
       end
 
       def from
@@ -88,7 +88,7 @@ module Ruboty
           return
         end
 
-        return case state['type']
+        case state['type']
         when 'static_select' then state.dig('selected_option', 'value')
         when 'multi_static_select' then state.dig('selected_options').map { |selected_option| selected_option['value'] }
         when 'multi_conversations_select' then state.dig('selected_conversations')
@@ -101,7 +101,7 @@ module Ruboty
         when 'plain_text_input' then state.dig('value')
         else
           Ruboty.logger.warn("#{self.class.name}: Cannot get state. This is unsupported type: #{state['type']}.")
-          return
+          nil
         end
       end
     end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -62,7 +62,7 @@ module Ruboty
           return
         end
 
-        robot.update(response_url, text)
+        robot.update_interactive(response_url, text, nil)
       end
 
       def update_blocks(blocks)
@@ -72,7 +72,7 @@ module Ruboty
           return
         end
 
-        robot.update_blocks(response_url, blocks)
+        robot.update_interactive(response_url, nil, blocks)
       end
 
       def state(block_id:, action_id:)

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -33,8 +33,16 @@ module Ruboty
         robot.say(attributes)
       end
 
+      def reply_blocks(blocks, options = {})
+        reply("", options.merge(blocks: blocks))
+      end
+
       def reply_as_ephemeral(body, options = {})
         reply(body, options.merge(ephemeral: true, user_id: user_id))
+      end
+
+      def reply_blocks_as_ephemeral(blocks, options = {})
+        reply("", options.merge(blocks: blocks, ephemeral: true, user_id: user_id))
       end
 
       def delete

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -46,6 +46,32 @@ module Ruboty
 
         robot.delete_interactive(response_url)
       end
+
+      def update(text: nil, block: nil)
+        response_url = @payload['response_url']
+        unless response_url
+          Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
+          return
+        end
+
+        if text.nil? && block.nil? || text && block
+          Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
+          return
+        end
+
+        if text.is_a?(String)
+          robot.update_interactive_message(response_url, text)
+        elsif block.is_a?(Array)
+          robot.update_interactive_block(response_url, block)
+        else
+          Ruboty.logger.warn("#{self.class.name}: Cannot update message. This is not match argument type.")
+          return
+        end
+      end
+
+      def selected_value(block_id, action_id)
+        @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
+      end
     end
   end
 end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -55,7 +55,7 @@ module Ruboty
         end
 
         if text.nil? && block.nil? || text && block
-          Ruboty.logger.warn("#{self.class.name}: Cannot update message. This message does not contain response_url in payload.")
+          Ruboty.logger.warn("#{self.class.name}: Cannot update message. Wrong number of arguments (expected text or block)")
           return
         end
 
@@ -70,7 +70,11 @@ module Ruboty
       end
 
       def selected_value(block_id, action_id)
-        @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
+        unless @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
+          Ruboty.logger.warn("#{self.class.name}: Cannot get selected value. Block_id or action_id is not found")
+          return
+        end
+        return @payload.dig('state', 'values', block_id, action_id, 'selected_option', 'value')
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/interactive_message.rb
+++ b/lib/ruboty/slack_socket_mode/interactive_message.rb
@@ -33,16 +33,18 @@ module Ruboty
         robot.say(attributes)
       end
 
-      def reply_ephemeral(body, options = {})
+      def reply_as_ephemeral(body, options = {})
         reply(body, options.merge(ephemeral: true, user_id: user_id))
       end
 
       def delete
-        unless payload['response_url']
-          Ruboty.logger.warn("#{self.class.name}: Cannot delete message. This is not an ephemeral message.")
+        response_url = payload['response_url']
+        unless response_url
+          Ruboty.logger.warn("#{self.class.name}: Cannot delete message. This message does not contain response_url in payload.")
           return
         end
-        @robot.delete_ephemeral_message(payload['response_url'])
+
+        robot.delete_interactive(response_url)
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/message.rb
+++ b/lib/ruboty/slack_socket_mode/message.rb
@@ -13,7 +13,7 @@ module Ruboty
         @original.dig(:user, "id")
       end
 
-      def reply_ephemeral(body, options = {})
+      def reply_as_ephemeral(body, options = {})
         reply(body, options.merge(ephemeral: true, user_id: user_id))
       end
 

--- a/lib/ruboty/slack_socket_mode/message.rb
+++ b/lib/ruboty/slack_socket_mode/message.rb
@@ -13,8 +13,16 @@ module Ruboty
         @original.dig(:user, "id")
       end
 
+      def reply_blocks(blocks, options = {})
+        reply("", options.merge(blocks: blocks))
+      end
+
       def reply_as_ephemeral(body, options = {})
         reply(body, options.merge(ephemeral: true, user_id: user_id))
+      end
+
+      def reply_blocks_as_ephemeral(blocks, options = {})
+        reply("", options.merge(blocks: blocks, ephemeral: true, user_id: user_id))
       end
     end
   end

--- a/lib/ruboty/slack_socket_mode/message.rb
+++ b/lib/ruboty/slack_socket_mode/message.rb
@@ -16,10 +16,6 @@ module Ruboty
       def reply_as_ephemeral(body, options = {})
         reply(body, options.merge(ephemeral: true, user_id: user_id))
       end
-
-      def delete
-        robot.delete_ephemeral_message(@original[:data]["response_url"])
-      end
     end
   end
 

--- a/lib/ruboty/slack_socket_mode/message.rb
+++ b/lib/ruboty/slack_socket_mode/message.rb
@@ -8,6 +8,14 @@ module Ruboty
         timestamp  = @original[:time].to_f
         robot.add_reaction(reaction, channel_id, timestamp)
       end
+
+      def reply_ephemeral(body, options = {})
+        reply(body, options.merge(ephemeral: true))
+      end
+
+      def delete
+        robot.delete_ephemeral_message(@original[:data]["response_url"])
+      end
     end
   end
 

--- a/lib/ruboty/slack_socket_mode/message.rb
+++ b/lib/ruboty/slack_socket_mode/message.rb
@@ -9,8 +9,12 @@ module Ruboty
         robot.add_reaction(reaction, channel_id, timestamp)
       end
 
+      def user_id
+        @original.dig(:user, "id")
+      end
+
       def reply_ephemeral(body, options = {})
-        reply(body, options.merge(ephemeral: true))
+        reply(body, options.merge(ephemeral: true, user_id: user_id))
       end
 
       def delete

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -5,14 +5,11 @@ module Ruboty
     module Robot
       include Mem
       delegate :add_reaction, to: :adapter
+      delegate :delete_interactive, to: :adapter
 
       def add_reaction(reaction, channel_id, timestamp)
         adapter.add_reaction(reaction, channel_id, timestamp)
         true
-      end
-
-      def delete_ephemeral_message(response_url)
-        adapter.delete_ephemeral_message(response_url)
       end
 
       def receive_events_api(event_type, data)

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -9,6 +9,10 @@ module Ruboty
         adapter.add_reaction(reaction, channel_id, timestamp)
         true
       end
+
+      def delete_ephemeral_message(response_url)
+        adapter.delete_ephemeral_message(response_url)
+      end
     end
   end
 

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -6,8 +6,7 @@ module Ruboty
       include Mem
       delegate :add_reaction, to: :adapter
       delegate :delete_interactive, to: :adapter
-      delegate :update_interactive_message, to: :adapter
-      delegate :update_interactive_block, to: :adapter
+      delegate :update_interactive, to: :adapter
 
       def add_reaction(reaction, channel_id, timestamp)
         adapter.add_reaction(reaction, channel_id, timestamp)

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -23,10 +23,10 @@ module Ruboty
         end
       end
 
-      def receive_interactive(action_id, data)
+      def receive_interactive(interactive_message)
         interactive_handlers.each do |handler|
           handler.class.actions.each do |action|
-            handler.send(action.method_name, data) if action.action_id == action_id
+            handler.send(action.method_name, interactive_message) if action.action_id == interactive_message.action_id
           end
         end
       end

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -6,6 +6,8 @@ module Ruboty
       include Mem
       delegate :add_reaction, to: :adapter
       delegate :delete_interactive, to: :adapter
+      delegate :update_interactive_message, to: :adapter
+      delegate :update_interactive_block, to: :adapter
 
       def add_reaction(reaction, channel_id, timestamp)
         adapter.add_reaction(reaction, channel_id, timestamp)

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -3,6 +3,7 @@ require 'ruboty/robot'
 module Ruboty
   module SlackSocketMode
     module Robot
+      include Mem
       delegate :add_reaction, to: :adapter
 
       def add_reaction(reaction, channel_id, timestamp)
@@ -13,6 +14,34 @@ module Ruboty
       def delete_ephemeral_message(response_url)
         adapter.delete_ephemeral_message(response_url)
       end
+
+      def receive_events_api(event_type, data)
+        events_api_handlers.each do |handler|
+          handler.class.actions.each do |action|
+            handler.send(action.method_name, data) if action.event_type == event_type
+          end
+        end
+      end
+
+      def receive_interactive(action_id, data)
+        interactive_handlers.each do |handler|
+          handler.class.actions.each do |action|
+            handler.send(action.method_name, data) if action.action_id == action_id
+          end
+        end
+      end
+
+      private
+
+      def events_api_handlers
+        Handlers.events_api.map { |handler_class| handler_class.new(self) }
+      end
+      memoize :events_api_handlers
+
+      def interactive_handlers
+        Handlers.interactive.map { |handler_class| handler_class.new(self) }
+      end
+      memoize :interactive_handlers
     end
   end
 

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -14,16 +14,16 @@ module Ruboty
 
       def receive_events_api(event_type, data)
         events_api_handlers.each do |handler|
-          handler.class.actions.each do |action|
-            handler.send(action.method_name, data) if action.event_type == event_type
+          handler.class.commands.each do |command|
+            handler.send(command.method_name, data) if command.event_type == event_type
           end
         end
       end
 
       def receive_interactive(interactive_message)
         interactive_handlers.each do |handler|
-          handler.class.actions.each do |action|
-            handler.send(action.method_name, interactive_message) if action.action_id == interactive_message.action_id
+          handler.class.commands.each do |command|
+            handler.send(command.method_name, interactive_message) if command.action_id == interactive_message.action_id
           end
         end
       end

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -6,7 +6,8 @@ module Ruboty
       include Mem
       delegate :add_reaction, to: :adapter
       delegate :delete_interactive, to: :adapter
-      delegate :update_interactive, to: :adapter
+      delegate :update_message, to: :adapter
+      delegate :update_blocks, to: :adapter
 
       def add_reaction(reaction, channel_id, timestamp)
         adapter.add_reaction(reaction, channel_id, timestamp)

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -6,7 +6,7 @@ module Ruboty
       include Mem
       delegate :add_reaction, to: :adapter
       delegate :delete_interactive, to: :adapter
-      delegate :update_message, to: :adapter
+      delegate :update, to: :adapter
       delegate :update_blocks, to: :adapter
 
       def add_reaction(reaction, channel_id, timestamp)

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -6,8 +6,7 @@ module Ruboty
       include Mem
       delegate :add_reaction, to: :adapter
       delegate :delete_interactive, to: :adapter
-      delegate :update, to: :adapter
-      delegate :update_blocks, to: :adapter
+      delegate :update_interactive, to: :adapter
 
       def add_reaction(reaction, channel_id, timestamp)
         adapter.add_reaction(reaction, channel_id, timestamp)

--- a/lib/ruboty/slack_socket_mode/robot.rb
+++ b/lib/ruboty/slack_socket_mode/robot.rb
@@ -8,11 +8,6 @@ module Ruboty
       delegate :delete_interactive, to: :adapter
       delegate :update_interactive, to: :adapter
 
-      def add_reaction(reaction, channel_id, timestamp)
-        adapter.add_reaction(reaction, channel_id, timestamp)
-        true
-      end
-
       def receive_events_api(event_type, data)
         events_api_handlers.each do |handler|
           handler.class.commands.each do |command|

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/events_api.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/events_api.rb
@@ -1,0 +1,13 @@
+module Ruboty::SlackSocketMode::Handlers
+  class EventsApi < EventsApiHandler
+    on(
+      event_type: 'app_home_opened',
+      name: 'app_home_opened'
+    )
+
+    def app_home_opened(message)
+      pp 'app_home_opened!'
+      pp message
+    end
+  end
+end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/events_api.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/events_api.rb
@@ -1,13 +1,12 @@
 module Ruboty::SlackSocketMode::Handlers
   class EventsApi < EventsApiHandler
-    on(
+    on_event(
       event_type: 'app_home_opened',
       name: 'app_home_opened'
     )
 
     def app_home_opened(message)
-      pp 'app_home_opened!'
-      pp message
+      puts "App Home: #{message["tab"]} tab is opened!"
     end
   end
 end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,0 +1,24 @@
+require "ruboty/sample_plugin/version"
+
+module Ruboty
+  module Handlers
+    class Interactive < Base
+      on(
+        /slack_interactive\:\:(?<action>.*)\z/,
+        name: 'slack_interactive',
+        description: 'Slack Interactive callback'
+      )
+
+      def slack_interactive(message)
+        action = message.match_data[:action]
+        interactive(action, message)
+      end
+
+      def interactive(action, message)
+        if action == 'action_ephemeral_ok'
+          message.delete
+        end
+      end
+    end
+  end
+end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -9,8 +9,8 @@ module Ruboty::SlackSocketMode::Handlers
       name: 'delete'
     )
     on_interactive(
-      action_id: 'action_update_message',
-      name: 'update_message'
+      action_id: 'action_update',
+      name: 'update'
     )
     on_interactive(
       action_id: 'action_update_blocks',
@@ -63,8 +63,8 @@ module Ruboty::SlackSocketMode::Handlers
       message.delete
     end
 
-    def update_message(message)
-      message.update_message("Update!")
+    def update(message)
+      message.update("Update!")
     end
 
     def update_blocks(message)

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,17 +1,20 @@
 module Ruboty::SlackSocketMode::Handlers
   class Interactive < InteractiveHandler
     on_interactive(
-      action_id: 'action_ephemeral_ok',
-      name: 'ephemeral_ok'
+      action_id: 'action_ephemeral_delete',
+      name: 'delete'
     )
     on_interactive(
-      action_id: 'increment',
-      name: 'ephemeral_ok'
+      action_id: 'action_ephemeral_more',
+      name: 'more'
     )
 
-    def ephemeral_ok(message)
+    def delete(message)
       message.delete
-      message.reply_ephemeral("Hello")
+    end
+
+    def more(message)
+      message.reply_ephemeral("Hello!")
     end
   end
 end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,8 +1,8 @@
 module Ruboty::SlackSocketMode::Handlers
   class Interactive < InteractiveHandler
     on_interactive(
-      action_id: 'action_select',
-      name: 'select'
+      action_id: 'action_get_form',
+      name: 'get_form'
     )
     on_interactive(
       action_id: 'action_delete',
@@ -24,9 +24,31 @@ module Ruboty::SlackSocketMode::Handlers
       action_id: 'action_more_ephemeral',
       name: 'more_ephemeral'
     )
+    def get_form(message)
+      static_select = message.state(block_id: "static_select", action_id: "static_select-action")
+      multi_static_select = message.state(block_id: "multi_static_select", action_id: "multi_static_select-action")
+      multi_conversations_select = message.state(block_id: "multi_conversations_select", action_id: "multi_conversations_select-action")
+      timepicker = message.state(block_id: "timepicker", action_id: "timepicker-action")
+      datepicker = message.state(block_id: "datepicker", action_id: "datepicker-action")
+      checkboxes = message.state(block_id: "checkboxes", action_id: "checkboxes-action")
+      radio_buttons = message.state(block_id: "radio_buttons", action_id: "radio_buttons-action")
+      users_select = message.state(block_id: "users_select", action_id: "users_select-action")
+      multi_users_select = message.state(block_id: "multi_users_select", action_id: "multi_users_select-action")
+      plain_text_input = message.state(block_id: "plain_text_input", action_id: "plain_text_input-action")
 
-    def select(message)
-      message.reply(message.selected_value("select","action_select"))
+      text = <<~EOF
+      static_select : #{static_select}
+      multi_static_select : #{multi_static_select}
+      multi_conversations_select : #{multi_conversations_select}
+      timepicker : #{timepicker}
+      datepicker : #{datepicker}
+      checkboxes : #{checkboxes}
+      radio_buttons : #{radio_buttons}
+      users_select : #{users_select}
+      multi_users_select : #{multi_users_select}
+      plain_text_input : #{plain_text_input}
+      EOF
+      message.reply(text)
     end
 
     def delete(message)

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -9,6 +9,14 @@ module Ruboty::SlackSocketMode::Handlers
       name: 'more'
     )
     on_interactive(
+      action_id: 'action_update_message',
+      name: 'update_message'
+    )
+    on_interactive(
+      action_id: 'action_update_block',
+      name: 'update_block'
+    )
+    on_interactive(
       action_id: 'action_more_ephemeral',
       name: 'more_ephemeral'
     )
@@ -21,8 +29,56 @@ module Ruboty::SlackSocketMode::Handlers
       message.reply("Hello, #{message.from_name}!")
     end
 
+    def update_message(message)
+      message.update(text: "Update!")
+    end
+
+    def update_block(message)
+      message.update(block: interactive_blocks)
+    end
+
     def more_ephemeral(message)
       message.reply_as_ephemeral("Hello, #{message.from_name}!")
+    end
+
+    private
+    def interactive_blocks
+      [
+        {
+          "type": "section",
+          "text": { "type": "plain_text", "text": "Push any buttons (updated)" }
+        },
+        {
+          "type": "actions",
+          "elements": [
+            {
+              "type": "button",
+              "text": { "type": "plain_text", "text": "Delete" },
+              "action_id": "action_delete"
+            },
+            {
+              "type": "button",
+              "text": { "type": "plain_text", "text": "More message" },
+              "action_id": "action_more"
+            },
+            {
+              "type": "button",
+              "text": { "type": "plain_text", "text": "Update message" },
+              "action_id": "action_update_messagee"
+            },
+            {
+              "type": "button",
+              "text": { "type": "plain_text", "text": "Update block" },
+              "action_id": "action_update_block"
+            },
+            {
+              "type": "button",
+              "text": { "type": "plain_text", "text": "More message (ephemeral)" },
+              "action_id": "action_more_ephemeral"
+            }
+          ]
+        }
+      ]
     end
   end
 end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -64,11 +64,11 @@ module Ruboty::SlackSocketMode::Handlers
     end
 
     def update_message(message)
-      message.update(text: "Update!")
+      message.update_message("Update!")
     end
 
     def update_blocks(message)
-      message.update(blocks: update_sample_blocks)
+      message.update_blocks(update_sample_blocks)
     end
 
     def more_message(message)

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,6 +1,10 @@
 module Ruboty::SlackSocketMode::Handlers
   class Interactive < InteractiveHandler
     on_interactive(
+      action_id: 'action_select',
+      name: 'select'
+    )
+    on_interactive(
       action_id: 'action_delete',
       name: 'delete'
     )
@@ -20,6 +24,10 @@ module Ruboty::SlackSocketMode::Handlers
       action_id: 'action_more_ephemeral',
       name: 'more_ephemeral'
     )
+
+    def select(message)
+      message.reply(message.selected_value("select","action_select"))
+    end
 
     def delete(message)
       message.delete
@@ -46,7 +54,7 @@ module Ruboty::SlackSocketMode::Handlers
       [
         {
           "type": "section",
-          "text": { "type": "plain_text", "text": "Push any buttons (updated)" }
+          "text": { "type": "plain_text", "text": "Update! Push Delete button" }
         },
         {
           "type": "actions",
@@ -55,26 +63,6 @@ module Ruboty::SlackSocketMode::Handlers
               "type": "button",
               "text": { "type": "plain_text", "text": "Delete" },
               "action_id": "action_delete"
-            },
-            {
-              "type": "button",
-              "text": { "type": "plain_text", "text": "More message" },
-              "action_id": "action_more"
-            },
-            {
-              "type": "button",
-              "text": { "type": "plain_text", "text": "Update message" },
-              "action_id": "action_update_messagee"
-            },
-            {
-              "type": "button",
-              "text": { "type": "plain_text", "text": "Update block" },
-              "action_id": "action_update_block"
-            },
-            {
-              "type": "button",
-              "text": { "type": "plain_text", "text": "More message (ephemeral)" },
-              "action_id": "action_more_ephemeral"
             }
           ]
         }

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -9,16 +9,16 @@ module Ruboty::SlackSocketMode::Handlers
       name: 'delete'
     )
     on_interactive(
-      action_id: 'action_more',
-      name: 'more'
-    )
-    on_interactive(
       action_id: 'action_update_message',
       name: 'update_message'
     )
     on_interactive(
       action_id: 'action_update_block',
       name: 'update_block'
+    )
+    on_interactive(
+      action_id: 'action_more',
+      name: 'more'
     )
     on_interactive(
       action_id: 'action_more_ephemeral',
@@ -33,16 +33,16 @@ module Ruboty::SlackSocketMode::Handlers
       message.delete
     end
 
-    def more(message)
-      message.reply("Hello, #{message.from_name}!")
-    end
-
     def update_message(message)
       message.update(text: "Update!")
     end
 
     def update_block(message)
       message.update(block: interactive_blocks)
+    end
+
+    def more(message)
+      message.reply("Hello, #{message.from_name}!")
     end
 
     def more_ephemeral(message)

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -4,9 +4,14 @@ module Ruboty::SlackSocketMode::Handlers
       action_id: 'action_ephemeral_ok',
       name: 'ephemeral_ok'
     )
+    on_interactive(
+      action_id: 'increment',
+      name: 'ephemeral_ok'
+    )
 
     def ephemeral_ok(message)
       message.delete
+      message.reply_ephemeral("Hello")
     end
   end
 end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,12 +1,16 @@
 module Ruboty::SlackSocketMode::Handlers
   class Interactive < InteractiveHandler
     on_interactive(
-      action_id: 'action_ephemeral_delete',
+      action_id: 'action_delete',
       name: 'delete'
     )
     on_interactive(
-      action_id: 'action_ephemeral_more',
+      action_id: 'action_more',
       name: 'more'
+    )
+    on_interactive(
+      action_id: 'action_more_ephemeral',
+      name: 'more_ephemeral'
     )
 
     def delete(message)
@@ -14,7 +18,11 @@ module Ruboty::SlackSocketMode::Handlers
     end
 
     def more(message)
-      message.reply_ephemeral("Hello!")
+      message.reply("Hello, #{message.from_name}!")
+    end
+
+    def more_ephemeral(message)
+      message.reply_as_ephemeral("Hello, #{message.from_name}!")
     end
   end
 end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,23 +1,13 @@
-require "ruboty/sample_plugin/version"
+module Ruboty::SlackSocketMode::Handlers
+  class Interactive < InteractiveHandler
+    on(
+      action_id: 'action_ephemeral_ok',
+      name: 'slack_interactive'
+    )
 
-module Ruboty
-  module Handlers
-    class Interactive < Base
-      on(
-        /slack_interactive\:\:(?<action>.*)\z/,
-        name: 'slack_interactive',
-        description: 'Slack Interactive callback'
-      )
-
-      def slack_interactive(message)
-        action = message.match_data[:action]
-        interactive(action, message)
-      end
-
-      def interactive(action, message)
-        if action == 'action_ephemeral_ok'
-          message.delete
-        end
+    def interactive(action, message)
+      if action == 'action_ephemeral_ok'
+        message.delete
       end
     end
   end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -38,7 +38,7 @@ module Ruboty::SlackSocketMode::Handlers
     end
 
     def update_block(message)
-      message.update(block: interactive_blocks)
+      message.update(blocks: interactive_blocks)
     end
 
     def more(message)

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -13,16 +13,24 @@ module Ruboty::SlackSocketMode::Handlers
       name: 'update_message'
     )
     on_interactive(
-      action_id: 'action_update_block',
-      name: 'update_block'
+      action_id: 'action_update_blocks',
+      name: 'update_blocks'
     )
     on_interactive(
-      action_id: 'action_more',
-      name: 'more'
+      action_id: 'action_more_message',
+      name: 'more_message'
     )
     on_interactive(
-      action_id: 'action_more_ephemeral',
-      name: 'more_ephemeral'
+      action_id: 'action_more_blocks',
+      name: 'more_blocks'
+    )
+    on_interactive(
+      action_id: 'action_more_ephemeral_message',
+      name: 'more_ephemeral_message'
+    )
+    on_interactive(
+      action_id: 'action_more_ephemeral_blocks',
+      name: 'more_ephemeral_blocks'
     )
     def get_form(message)
       static_select = message.state(block_id: "static_select", action_id: "static_select-action")
@@ -59,24 +67,50 @@ module Ruboty::SlackSocketMode::Handlers
       message.update(text: "Update!")
     end
 
-    def update_block(message)
-      message.update(blocks: interactive_blocks)
+    def update_blocks(message)
+      message.update(blocks: update_sample_blocks)
     end
 
-    def more(message)
+    def more_message(message)
       message.reply("Hello, #{message.from_name}!")
     end
 
-    def more_ephemeral(message)
+    def more_blocks(message)
+      message.reply_blocks(reply_sample_blocks)
+    end
+
+    def more_ephemeral_message(message)
       message.reply_as_ephemeral("Hello, #{message.from_name}!")
     end
 
+    def more_ephemeral_blocks(message)
+      message.reply_blocks_as_ephemeral(reply_sample_blocks)
+    end
+
     private
-    def interactive_blocks
+    def update_sample_blocks
       [
         {
           "type": "section",
           "text": { "type": "plain_text", "text": "Update! Push Delete button" }
+        },
+        {
+          "type": "actions",
+          "elements": [
+            {
+              "type": "button",
+              "text": { "type": "plain_text", "text": "Delete" },
+              "action_id": "action_delete"
+            }
+          ]
+        }
+      ]
+    end
+    def reply_sample_blocks
+      [
+        {
+          "type": "section",
+          "text": { "type": "plain_text", "text": "More message! Push Delete button" }
         },
         {
           "type": "actions",

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -32,6 +32,7 @@ module Ruboty::SlackSocketMode::Handlers
       action_id: 'action_more_ephemeral_blocks',
       name: 'more_ephemeral_blocks'
     )
+
     def get_form(message)
       static_select = message.state(block_id: "static_select", action_id: "static_select-action")
       multi_static_select = message.state(block_id: "multi_static_select", action_id: "multi_static_select-action")
@@ -88,6 +89,7 @@ module Ruboty::SlackSocketMode::Handlers
     end
 
     private
+
     def update_sample_blocks
       [
         {
@@ -106,6 +108,7 @@ module Ruboty::SlackSocketMode::Handlers
         }
       ]
     end
+
     def reply_sample_blocks
       [
         {

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb
@@ -1,14 +1,12 @@
 module Ruboty::SlackSocketMode::Handlers
   class Interactive < InteractiveHandler
-    on(
+    on_interactive(
       action_id: 'action_ephemeral_ok',
-      name: 'slack_interactive'
+      name: 'ephemeral_ok'
     )
 
-    def interactive(action, message)
-      if action == 'action_ephemeral_ok'
-        message.delete
-      end
+    def ephemeral_ok(message)
+      message.delete
     end
   end
 end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -75,9 +75,9 @@ module Ruboty
                 "action_id": "action_delete"
               },
               {
-              "type": "button",
-              "text": { "type": "plain_text", "text": "Update message" },
-              "action_id": "action_update_message"
+                "type": "button",
+                "text": { "type": "plain_text", "text": "Update message" },
+                "action_id": "action_update_message"
               },
               {
                 "type": "button",

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -47,7 +47,7 @@ module Ruboty
       end
 
       def reply_interactive(message)
-        message.reply_blocks(interactive_blocks)
+        message.reply('This is interactive message', blocks: interactive_blocks)
       end
 
       def reply_interactive_as_ephemeral(message)

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -1,0 +1,60 @@
+require "ruboty/sample_plugin/version"
+
+module Ruboty
+  module Handlers
+    class Trigger < Base
+      on(
+        /attachment/i,
+        name: 'reply_with_attachments',
+        description: 'reply with attachments',
+      )
+      on(
+        /file/i,
+        name: 'reply_with_file_attachment',
+        description: 'reply with a file attachment',
+      )
+      on(
+        /ephemeral/i,
+        name: 'reply_ephemeral',
+        description: 'reply elphemeral message',
+      )
+
+      def reply_with_attachments(message)
+        message.reply('', attachments: [{
+          "text": "This is an attachment",
+          "id": 1,
+          "fallback": "This is an attachment's fallback"
+        }])
+      end
+
+      def reply_with_file_attachment(message)
+        message.reply('', file: {
+            path: 'sample_file',
+            title: 'sample_file',
+            content_type: 'text/plain'
+          }
+        )
+      end
+
+      def reply_ephemeral(message)
+        message.reply_ephemeral(
+          'this is ephemeral message',
+          blocks: [
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "This is ephemeral message"
+              },
+              "accessory": {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "OK" },
+                "action_id": "action_ephemeral_ok"
+              }
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -4,19 +4,24 @@ module Ruboty
   module Handlers
     class Trigger < Base
       on(
-        /attachment/i,
+        /attachment\z/i,
         name: 'reply_with_attachments',
         description: 'reply with attachments',
       )
       on(
-        /file/i,
+        /file\z/i,
         name: 'reply_with_file_attachment',
         description: 'reply with a file attachment',
       )
       on(
-        /ephemeral/i,
-        name: 'reply_ephemeral',
-        description: 'reply elphemeral message',
+        /interactive\z/i,
+        name: 'reply_interactive',
+        description: 'reply an interactive message',
+      )
+      on(
+        /interactive_ephemeral\z/i,
+        name: 'reply_interactive_as_ephemeral',
+        description: 'reply an interactive message as ephemeral',
       )
 
       def reply_with_attachments(message)
@@ -36,31 +41,43 @@ module Ruboty
         )
       end
 
-      def reply_ephemeral(message)
-        message.reply_ephemeral(
-          'this is ephemeral message',
-          blocks: [
-            {
-              "type": "section",
-              "text": { "type": "plain_text", "text": "This is ephemeral message" }
-            },
-            {
-              "type": "actions",
-              "elements": [
-                {
-                  "type": "button",
-                  "text": { "type": "plain_text", "text": "Delete" },
-                  "action_id": "action_ephemeral_delete"
-                },
-                {
-                  "type": "button",
-                  "text": { "type": "plain_text", "text": "More Message" },
-                  "action_id": "action_ephemeral_more"
-                }
-              ]
-            }
-          ]
-        )
+      def reply_interactive(message)
+        message.reply('This is interactive message', blocks: interactive_blocks)
+      end
+
+      def reply_interactive_as_ephemeral(message)
+        message.reply_as_ephemeral('This is ephemeral interactive message', blocks: interactive_blocks)
+      end
+
+      private
+
+      def interactive_blocks
+        [
+          {
+            "type": "section",
+            "text": { "type": "plain_text", "text": "Push any buttons" }
+          },
+          {
+            "type": "actions",
+            "elements": [
+              {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "Delete" },
+                "action_id": "action_delete"
+              },
+              {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "More message" },
+                "action_id": "action_more"
+              },
+              {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "More message (ephemeral)" },
+                "action_id": "action_more_ephemeral"
+              }
+            ]
+          }
+        ]
       end
     end
   end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -23,6 +23,11 @@ module Ruboty
         name: 'reply_interactive_as_ephemeral',
         description: 'reply an interactive message as ephemeral',
       )
+      on(
+        /interactive_form\z/i,
+        name: 'reply_interactive_form',
+        description: 'reply an interactive message',
+      )
 
       def reply_with_attachments(message)
         message.reply('', attachments: [{
@@ -49,6 +54,10 @@ module Ruboty
         message.reply_as_ephemeral('This is ephemeral interactive message', blocks: interactive_blocks)
       end
 
+      def reply_interactive_form(message)
+        message.reply('This is interactive form', blocks: interactive_form)
+      end
+
       private
 
       def interactive_blocks
@@ -56,49 +65,6 @@ module Ruboty
           {
             "type": "section",
             "text": { "type": "plain_text", "text": "Push any buttons" }
-          },
-          {
-            "type": "section",
-            "block_id": "select",
-            "text": {
-              "type": "mrkdwn",
-              "text": "please select"
-            },
-            "accessory": {
-              "type": "static_select",
-              "placeholder": {
-                "type": "plain_text",
-                "text": "Select an item",
-                "emoji": true
-              },
-              "options": [
-                {
-                  "text": {
-                    "type": "plain_text",
-                    "text": "item-1",
-                    "emoji": true
-                  },
-                  "value": "item-1"
-                },
-                {
-                  "text": {
-                    "type": "plain_text",
-                    "text": "item-2",
-                    "emoji": true
-                  },
-                  "value": "item-2"
-                },
-                {
-                  "text": {
-                    "type": "plain_text",
-                    "text": "item-3",
-                    "emoji": true
-                  },
-                  "value": "item-3"
-                }
-              ],
-              "action_id": "action_select"
-            }
           },
           {
             "type": "actions",
@@ -129,6 +95,300 @@ module Ruboty
                 "action_id": "action_more_ephemeral"
               }
             ]
+          }
+        ]
+      end
+
+      def interactive_form
+        [
+          {
+            "type": "section",
+            "block_id": "static_select",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Pick an item from the dropdown list"
+            },
+            "accessory": {
+              "type": "static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select an item",
+                "emoji": true
+              },
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-0",
+                    "emoji": true
+                  },
+                  "value": "value-0"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-1",
+                    "emoji": true
+                  },
+                  "value": "value-1"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-2",
+                    "emoji": true
+                  },
+                  "value": "value-2"
+                }
+              ],
+              "action_id": "static_select-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "multi_static_select",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Test block with multi static select"
+            },
+            "accessory": {
+              "type": "multi_static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select options",
+                "emoji": true
+              },
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-0",
+                    "emoji": true
+                  },
+                  "value": "value-0"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-1",
+                    "emoji": true
+                  },
+                  "value": "value-1"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-2",
+                    "emoji": true
+                  },
+                  "value": "value-2"
+                }
+              ],
+              "action_id": "multi_static_select-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "multi_conversations_select",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Test block with multi conversations select"
+            },
+            "accessory": {
+              "type": "multi_conversations_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select conversations",
+                "emoji": true
+              },
+              "action_id": "multi_conversations_select-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "datepicker",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Pick a date for the deadline."
+            },
+            "accessory": {
+              "type": "datepicker",
+              "initial_date": "1990-04-28",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select a date",
+                "emoji": true
+              },
+              "action_id": "datepicker-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "checkboxes",
+            "text": {
+              "type": "mrkdwn",
+              "text": "This is a section block with checkboxes."
+            },
+            "accessory": {
+              "type": "checkboxes",
+              "options": [
+                {
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "value-0"
+                  },
+                  "description": {
+                    "type": "mrkdwn",
+                    "text": "discription"
+                  },
+                  "value": "value-0"
+                },
+                {
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "value-1"
+                  },
+                  "description": {
+                    "type": "mrkdwn",
+                    "text": "discription"
+                  },
+                  "value": "value-1"
+                },
+                {
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "value-2"
+                  },
+                  "description": {
+                    "type": "mrkdwn",
+                    "text": "description"
+                  },
+                  "value": "value-2"
+                }
+              ],
+              "action_id": "checkboxes-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "radio_buttons",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Section block with radio buttons"
+            },
+            "accessory": {
+              "type": "radio_buttons",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-0",
+                    "emoji": true
+                  },
+                  "value": "value-0"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-1",
+                    "emoji": true
+                  },
+                  "value": "value-1"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "value-2",
+                    "emoji": true
+                  },
+                  "value": "value-2"
+                }
+              ],
+              "action_id": "radio_buttons-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "timepicker",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Section block with a timepicker"
+            },
+            "accessory": {
+              "type": "timepicker",
+              "initial_time": "13:37",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select time",
+                "emoji": true
+              },
+              "action_id": "timepicker-action"
+            }
+          },
+          {
+            "type": "section",
+            "block_id": "users_select",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Test block with users select"
+            },
+            "accessory": {
+              "type": "users_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select a user",
+                "emoji": true
+              },
+              "action_id": "users_select-action"
+            }
+          },
+          {
+            "type": "input",
+            "block_id": "multi_users_select",
+            "element": {
+              "type": "multi_users_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select users",
+                "emoji": true
+              },
+              "action_id": "multi_users_select-action"
+            },
+            "label": {
+              "type": "plain_text",
+              "text": "Label",
+              "emoji": true
+            }
+          },
+          {
+            "type": "input",
+            "block_id": "plain_text_input",
+            "element": {
+              "type": "plain_text_input",
+              "action_id": "plain_text_input-action"
+            },
+            "label": {
+              "type": "plain_text",
+              "text": "Label",
+              "emoji": true
+            }
+          },
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "This is a section block with a button."
+            },
+            "accessory": {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "text": "get_form",
+                "emoji": true
+              },
+              "value": "get_form",
+              "action_id": "action_get_form"
+            }
           }
         ]
       end

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -109,11 +109,6 @@ module Ruboty
                 "action_id": "action_delete"
               },
               {
-                "type": "button",
-                "text": { "type": "plain_text", "text": "More message" },
-                "action_id": "action_more"
-              },
-              {
               "type": "button",
               "text": { "type": "plain_text", "text": "Update message" },
               "action_id": "action_update_message"
@@ -122,6 +117,11 @@ module Ruboty
                 "type": "button",
                 "text": { "type": "plain_text", "text": "Update block" },
                 "action_id": "action_update_block"
+              },
+              {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "More message" },
+                "action_id": "action_more"
               },
               {
                 "type": "button",

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -42,15 +42,22 @@ module Ruboty
           blocks: [
             {
               "type": "section",
-              "text": {
-                "type": "mrkdwn",
-                "text": "This is ephemeral message"
-              },
-              "accessory": {
-                "type": "button",
-                "text": { "type": "plain_text", "text": "OK" },
-                "action_id": "action_ephemeral_ok"
-              }
+              "text": { "type": "plain_text", "text": "This is ephemeral message" }
+            },
+            {
+              "type": "actions",
+              "elements": [
+                {
+                  "type": "button",
+                  "text": { "type": "plain_text", "text": "Delete" },
+                  "action_id": "action_ephemeral_delete"
+                },
+                {
+                  "type": "button",
+                  "text": { "type": "plain_text", "text": "More Message" },
+                  "action_id": "action_ephemeral_more"
+                }
+              ]
             }
           ]
         )

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -58,6 +58,49 @@ module Ruboty
             "text": { "type": "plain_text", "text": "Push any buttons" }
           },
           {
+            "type": "section",
+            "block_id": "select",
+            "text": {
+              "type": "mrkdwn",
+              "text": "please select"
+            },
+            "accessory": {
+              "type": "static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "Select an item",
+                "emoji": true
+              },
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "item-1",
+                    "emoji": true
+                  },
+                  "value": "item-1"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "item-2",
+                    "emoji": true
+                  },
+                  "value": "item-2"
+                },
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "item-3",
+                    "emoji": true
+                  },
+                  "value": "item-3"
+                }
+              ],
+              "action_id": "action_select"
+            }
+          },
+          {
             "type": "actions",
             "elements": [
               {

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -47,15 +47,15 @@ module Ruboty
       end
 
       def reply_interactive(message)
-        message.reply('This is interactive message', blocks: interactive_blocks)
+        message.reply_blocks(interactive_blocks)
       end
 
       def reply_interactive_as_ephemeral(message)
-        message.reply_as_ephemeral('This is ephemeral interactive message', blocks: interactive_blocks)
+        message.reply_blocks_as_ephemeral(interactive_blocks)
       end
 
       def reply_interactive_form(message)
-        message.reply('This is interactive form', blocks: interactive_form)
+        message.reply_blocks(interactive_form)
       end
 
       private
@@ -81,18 +81,28 @@ module Ruboty
               },
               {
                 "type": "button",
-                "text": { "type": "plain_text", "text": "Update block" },
-                "action_id": "action_update_block"
+                "text": { "type": "plain_text", "text": "Update blocks" },
+                "action_id": "action_update_blocks"
               },
               {
                 "type": "button",
                 "text": { "type": "plain_text", "text": "More message" },
-                "action_id": "action_more"
+                "action_id": "action_more_message"
+              },
+              {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "More blocks" },
+                "action_id": "action_more_blocks"
               },
               {
                 "type": "button",
                 "text": { "type": "plain_text", "text": "More message (ephemeral)" },
-                "action_id": "action_more_ephemeral"
+                "action_id": "action_more_ephemeral_message"
+              },
+              {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "More blocks (ephemeral)" },
+                "action_id": "action_more_ephemeral_blocks"
               }
             ]
           }

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -77,7 +77,7 @@ module Ruboty
               {
                 "type": "button",
                 "text": { "type": "plain_text", "text": "Update message" },
-                "action_id": "action_update_message"
+                "action_id": "action_update"
               },
               {
                 "type": "button",

--- a/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb
@@ -71,6 +71,16 @@ module Ruboty
                 "action_id": "action_more"
               },
               {
+              "type": "button",
+              "text": { "type": "plain_text", "text": "Update message" },
+              "action_id": "action_update_message"
+              },
+              {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "Update block" },
+                "action_id": "action_update_block"
+              },
+              {
                 "type": "button",
                 "text": { "type": "plain_text", "text": "More message (ephemeral)" },
                 "action_id": "action_more_ephemeral"

--- a/sample/ruboty-sample_plugin/lib/ruboty/sample_plugin.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/sample_plugin.rb
@@ -1,35 +1,3 @@
-require "ruboty/sample_plugin/version"
-
-module Ruboty
-  module Handlers
-    class SamplePlugin < Base
-      on(
-        /attachment/i,
-        name: 'reply_with_attachments',
-        description: 'reply with attachments',
-      )
-      on(
-        /file/i,
-        name: 'reply_with_file_attachment',
-        description: 'reply with a file attachment',
-      )
-
-      def reply_with_attachments(message)
-        message.reply('', attachments: [{
-          "text": "This is an attachment",
-          "id": 1,
-          "fallback": "This is an attachment's fallback"
-        }])
-      end
-
-      def reply_with_file_attachment(message)
-        message.reply('', file: {
-            path: 'sample_file',
-            title: 'sample_file',
-            content_type: 'text/plain'
-          }
-        )
-      end
-    end
-  end
-end
+require 'ruboty/sample_plugin/version'
+require 'ruboty/handlers/trigger'
+require 'ruboty/handlers/interactive'

--- a/sample/ruboty-sample_plugin/lib/ruboty/sample_plugin.rb
+++ b/sample/ruboty-sample_plugin/lib/ruboty/sample_plugin.rb
@@ -1,3 +1,5 @@
 require 'ruboty/sample_plugin/version'
+
 require 'ruboty/handlers/trigger'
 require 'ruboty/handlers/interactive'
+require 'ruboty/handlers/events_api'


### PR DESCRIPTION
## What's this
Slackの Events API, および Interactive なイベントを Ruboty で扱えるようにします。
また、 Interactive なイベントを扱うにあたり必要になりそうな機能拡張をしています。

## Concept
Rubotyの通常のUsageでは、 `@ruboty ping` のように自分へのメンションが入ったテキストをコマンドとして検知します。
Slack App として扱うものが全て上記のようなパターンなのであればこれで十分なのですが、 `Events API` や インタラクティブUI に対する応答を行う場合、コマンドとして扱うのは厳しさがあります。

そこで、専用の Handler 共通クラスを用意しました。App開発者はそれを継承したクラスを作成することで任意の `Events API` や インタラクティブUI への処理を記載することができます。

Bot を開発する側の視点としては、下のファイルなどを参照するとわかりやすいかと思います。

- [sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb](https://github.com/reproio/ruboty-slack_socket_mode/blob/develop/sample/ruboty-sample_plugin/lib/ruboty/handlers/trigger.rb)
  - 通常のテキストコマンドから Interactive なメッセージを reply するサンプルがあります。
- [sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb](https://github.com/reproio/ruboty-slack_socket_mode/blob/develop/sample/ruboty-sample_plugin/lib/ruboty/handlers/interactive.rb)
  - Interactive UI のボタンに反応して UI を更新したり、追加したりするサンプルがあります。
- [sample/ruboty-sample_plugin/lib/ruboty/handlers/events_api.rb](https://github.com/reproio/ruboty-slack_socket_mode/blob/develop/sample/ruboty-sample_plugin/lib/ruboty/handlers/events_api.rb) 
  - こちらは Interactive と直接関連しませんが、Events API をハンドリングするサンプルです。

## Implemented features

### Ephemeral message を post できるようにした
- Interactive メッセージのやり取りに欠かせない（と思われる）ものです。
- Handler/Action からは `message.reply_as_ephemeral` という形で使えます。

### [BlockKitのJSON](https://api.slack.com/block-kit)を reply に含められるようにした
- Interactive なメッセージのやり取りの基礎になるものです。
- `message.reply(text', blocks: [...])` あるいは `message.reply_blocks([...])` の形で使えます。
- `reply_as_ephemeral('text', blocks: [...])` `reply_blocks_as_ephemeral([...])` も使えます。
  実際にはこちらを使うことが多くなると思います。

### Events API / Interactive を Ruboty Handler で取り扱えるようにした
- Block Kit のボタンや入力を受け取る Handler を作ることができるようになります。
- `Ruboty::SlackSocketMode::Handlers::InteractiveHandler` を継承した Handler を作ることで実現できます。
- 通常の Ruboty Handler とは別の空間で管理しているので、`@ruboty help` の結果に影響はありません。
- 同様の形で `Ruboty::SlackSocketMode::Handlers::EventsApiHandler` も存在しています。

### Bot自身の Interactive なメッセージを削除、更新できるようにした
Block Kit のボタンや入力を受け取った時、`InteractiveMessage` クラスのインスタンスが Handler に渡されます。
Interactive なメッセージでは状況に応じた UI の更新が必要なので、下記の通りメソッドを整備しました。

- `message.delete` でメッセージの削除ができます。操作の完了時などに使われる想定です。
- `message.update` で内容の更新ができます。UIをstep by step的に更新する場合などに使う想定です。

## Merged PRs to `develop`
- https://github.com/reproio/ruboty-slack_socket_mode/pull/3
    - Ruboty のコアを拡張し、 Interactive や Events API 専用の Handler などを作成したものです。
    - そこそこ前ですが、このPRは @takaishi さんにはレビューしていただいていました。
- https://github.com/reproio/ruboty-slack_socket_mode/pull/4
    - BlockKit UI のフォーム（テキストや選択ボックス）の値にアクセスしやすいよう、メソッドの拡張を行ったものです。
- https://github.com/reproio/ruboty-slack_socket_mode/pull/5
    - BlockKit UI のメッセージをやりとりすることが多いと、 `Message#reply` メソッドだけだと不便さがありました。
    - これを緩和するために、ショートハンド的なメソッドをいくつか作成したものです。

## Working image
<details><summary>インタラクティブなメッセージを連続的にやりとりするサンプル</summary>

![Untitled](https://user-images.githubusercontent.com/98291974/181422649-df5a66fa-dce7-4083-996c-354be629cc48.gif)

</details>

<details><summary>入力フォームの値を受け取るサンプル</summary>

![Untitled2](https://user-images.githubusercontent.com/98291974/181422663-fbbc83ef-2f64-4b83-8185-44219b7f6f77.gif)

</details>
